### PR TITLE
Use single scatterplot to show selected places and hovered items

### DIFF
--- a/src/components/map-view/ConnectedScatterplot.js
+++ b/src/components/map-view/ConnectedScatterplot.js
@@ -24,6 +24,7 @@ const getBaseSeries = (data, selected, x, y, z) => {
     symbolSize: (value) => sizeScale(value[2]),
     itemStyle: {
       'emphasis': {
+        color: '#f00',
         borderColor: '#ff0000',
         borderWidth: 2
       }

--- a/src/components/map-view/ConnectedScatterplot.js
+++ b/src/components/map-view/ConnectedScatterplot.js
@@ -5,13 +5,14 @@ import Scatterplot from '../scatterplot/Scatterplot';
 import { getScatterplotData, getDataScale } from '../../utils';
 import { scatterOptions } from '../../constants/scatterOptions';
 import * as _isEmpty from 'lodash.isempty';
-import { onHoverFeature, onViewportChange } from '../../actions/mapActions';
+import { onHoverFeature, onViewportChange, onCoordsChange } from '../../actions/mapActions';
 import { fetchResults } from '../../actions/searchActions';
 import { loadLocation } from '../../actions/featuresActions';
 import { loadVarsForRegion } from '../../actions/scatterplotActions';
 import * as _debounce from 'lodash.debounce';
 import * as _isEqual from 'lodash.isequal';
 
+/** Get series with default styles and selected areas */
 const getBaseSeries = (data, selected, x, y, z) => { 
   const sizeScale = 
     getDataScale(data[z], { range: [ 5, 40 ] });
@@ -225,7 +226,7 @@ export class ConnectedScatterplot extends Component {
       this.props.loadMetadataForPlace(feature.id)
     }
     this.props.onHover && this.props.onHover(data);
-  }, 100);
+  }, 40);
 
   _onReady = (echart) => {
     this.echart = echart;
@@ -236,8 +237,15 @@ export class ConnectedScatterplot extends Component {
     if(data && data[3]) {
       this.props.onHoverFeature(null)
     }
+    
     // call debounced hover function
     this._handleHover(data, e);
+  }
+
+  _onMouseMove = (e) => {
+    this.props.onCoordsChange({
+      x: e.event.event.clientX, y: e.event.event.clientY
+    })
   }
 
   render() {
@@ -245,6 +253,7 @@ export class ConnectedScatterplot extends Component {
       <Scatterplot 
         onReady={this._onReady}
         onHover={this._onHover}
+        onMouseMove={this._onMouseMove}
         onClick={this._handleClick}
         options={this.state.options}
       />  
@@ -282,6 +291,8 @@ const mapStateToProps = (
 const mapDispatchToProps = (dispatch) => ({
   onHoverFeature: (feature) =>
     dispatch(onHoverFeature(feature)),
+  onCoordsChange: (coords) =>
+    dispatch(onCoordsChange(coords)),
   loadMetadataForPlace: (id) =>
     dispatch(fetchResults(id)),
   loadVarsForRegion: (vars, region) => 

--- a/src/components/map-view/ConnectedScatterplot.js
+++ b/src/components/map-view/ConnectedScatterplot.js
@@ -4,52 +4,67 @@ import { connect } from 'react-redux'
 import Scatterplot from '../scatterplot/Scatterplot';
 import { getScatterplotData, getDataScale } from '../../utils';
 import { scatterOptions } from '../../constants/scatterOptions';
+import * as _isEmpty from 'lodash.isempty';
+import { onHoverFeature, onViewportChange } from '../../actions/mapActions';
+import { fetchResults } from '../../actions/searchActions';
+import { loadLocation } from '../../actions/featuresActions';
+import { loadVarsForRegion } from '../../actions/scatterplotActions';
+import * as _debounce from 'lodash.debounce';
+import * as _isEqual from 'lodash.isequal';
+
+const getBaseSeries = (data, selected, x, y, z) => { 
+  const sizeScale = 
+    getDataScale(data[z], { range: [ 5, 40 ] });
+  const scatterData = getScatterplotData(data[x], data[y], data[z]);
+  return {
+    id: 'scatter',
+    type: 'scatter',
+    data: scatterData,
+    symbolSize: (value) => sizeScale(value[2]),
+    itemStyle: {
+      'emphasis': {
+        borderColor: '#ff0000',
+        borderWidth: 2
+      }
+    },
+    markPoint: {
+      data: Object.keys(selected).map((id) => {
+        const point = scatterData.find(d => d[3] === id);
+        return {
+          name: id,
+          coord: [point[0], point[1]],
+          symbol: 'circle',
+          symbolSize: sizeScale(point[2]),
+          itemStyle: {
+            borderColor: selected[id],
+            borderWidth: 2,
+            color: 'rgba(0,0,0,0)',
+            shadowColor: '#fff',
+            shadowBlur: 2
+          }
+        }
+      })
+    }
+  }
+}
 
 /**
  * Gets scatterplot data series based on state and props
  * @param {*} state 
  * @param {*} props 
  */
-const getScatterplotSeries = (
-  { scatterplot: { data } }, 
-  { xVar, yVar, zVar = 'sz', region }
-) => { 
-  if (
-    data[region] && data[region][xVar] &&
-    data[region][yVar] && data[region][zVar]
-  ) {
-    const sizeScale = getDataScale(
-      data[region][zVar],
-      { range: [ 5, 40 ] }
-    );
+const getScatterplotSeries = (data, selected, x, y, z) => { 
+  if (data && data[x] && data[y] && data[z]) {
     return [
-      {
-        id: 'scatter',
-        type: 'scatter',
-        data: getScatterplotData(
-          data[region][xVar],
-          data[region][yVar],
-          data[region][zVar]
-        ),
-        symbolSize: (value) => sizeScale(value[2])
-      }
+      getBaseSeries(data, selected, x, y, z)
     ];
   }
   return [];
 }
 
-/**
- * Gets the options with series data for the scatterplot
- * @param {array} series data series array for scatterplot
- * @param {object} overrides option overrides to defaults
- */
-const getScatterplotOptions = (series, overrides) => {
-  const options = { 
-    ...scatterOptions, 
-    ...overrides, 
-    series 
-  };
-  return options;
+
+const getDataIndex = (id, series) => {
+  return series.findIndex(d => d[3] === id)
 }
 
 export class ConnectedScatterplot extends Component {
@@ -61,7 +76,16 @@ export class ConnectedScatterplot extends Component {
     region: PropTypes.string,
     options: PropTypes.object,
     onHover: PropTypes.func,
-    onClick: PropTypes.func
+    onClick: PropTypes.func,
+    hoveredFeature: PropTypes.object,
+    onHoverFeature: PropTypes.func,
+    loadMetadataForPlace: PropTypes.func,
+    hoveredMetaData: PropTypes.object,
+    updateMapViewport: PropTypes.func,
+    addSelectedLocation: PropTypes.func,
+    loadVarsForRegion: PropTypes.func,
+    data: PropTypes.object,
+    hoveredId: PropTypes.string,
   }
 
   constructor(props) {
@@ -70,45 +94,211 @@ export class ConnectedScatterplot extends Component {
   }
 
   componentDidMount() {
-    const { series, options } = this.props;
+    this._loadScatterplotData();
     this.setState({
-      options: getScatterplotOptions(series, options)
+      options: this._getScatterplotOptions()
     });
   }
 
   componentDidUpdate(prevProps) {
-    const { region, xVar, yVar, zVar, series, options } = this.props;
-    // update the state when data is available
+    const { region, xVar, yVar, zVar, series, hoveredId, selected } = this.props;    
+    // load data if needed
     if (
-      prevProps.series.length !== series.length ||
       prevProps.region !== region ||
       prevProps.xVar !== xVar ||
       prevProps.zVar !== zVar ||
       prevProps.yVar !== yVar
     ) {
+      this._loadScatterplotData();
+    }
+    // update the options in state when props change
+    if (
+      prevProps.series.length !== series.length ||
+      prevProps.region !== region ||
+      prevProps.xVar !== xVar ||
+      prevProps.zVar !== zVar ||
+      prevProps.yVar !== yVar ||
+      !_isEqual(prevProps.selected, selected)
+    ) {
       this.setState({
-        options: getScatterplotOptions(series, options)
+        options: this._getScatterplotOptions()
       });
+    }
+    // update highlighted dots when hovered changes
+    if (prevProps.hoveredId !== hoveredId) {
+      this._removeHighlight(prevProps.hoveredId)
+      if (hoveredId) {
+        this._addHighlight(hoveredId);
+      }
     }
   }
 
+  /**
+   * Gets the options with series data for the scatterplot
+   * @param {array} series data series array for scatterplot
+   * @param {object} overrides option overrides to defaults
+   */
+  _getScatterplotOptions = () => {
+    const { options, series } = this.props;
+    const fullOptions = { 
+      ...scatterOptions, 
+      ...options,
+      series 
+    };
+    return fullOptions;
+  }
+
+  /**
+   * 
+   */
+  _loadScatterplotData() {
+    const { data, region, xVar, yVar, zVar, loadVarsForRegion } = this.props;
+    const vars = [];
+    zVar && (!data || !data[zVar]) && vars.push(zVar);
+    xVar && (!data || !data[xVar]) && vars.push(xVar);
+    yVar && (!data || !data[yVar]) && vars.push(yVar);
+    if (vars.length === 0) { return; }
+    loadVarsForRegion(vars, region);
+  }
+
+  /**
+   * Adds a highlight on the item with the corresponding ID
+   */
+  _addHighlight(hoveredId) {
+    const { series } = this.props;
+    if (this.echart && hoveredId) {
+      this.echart.dispatchAction({
+        type: 'highlight',
+        seriesIndex: 0,
+        dataIndex: getDataIndex(hoveredId, series[0].data)
+      })
+    }
+  }
+
+  /**
+   * Removes highlighted items from the scatterplot
+   */
+  _removeHighlight(hoveredId) {
+    const { series } = this.props;
+    this.echart && this.echart.dispatchAction({
+      type: 'downplay',
+      seriesIndex: 0,
+      dataIndex: getDataIndex(hoveredId, series[0].data)
+    })
+  }
+
+  /**
+   * Add location to selected list on click
+   */
+  _handleClick = (e) => {
+    const { updateMapViewport, hoveredFeature, hoveredMetaData } = this.props;
+    if (!_isEmpty(this.props.hoveredMetaData)) {
+      this.props.addSelectedLocation({
+        id: hoveredMetaData.id,
+        latitude: hoveredMetaData.lat,
+        longitude: hoveredMetaData.lon
+      })
+      updateMapViewport(hoveredFeature, hoveredMetaData)
+    }
+    this.props.onClick && this.props.onClick(e)
+  }
+
+  /**
+   * Set hovered feature and load metadata for location
+   * when hovering dots
+   */
+  _handleHover = _debounce((data) => {
+    if (!data) {
+      return this.props.onHoverFeature(null, {x:0,y:0});
+    }
+    const feature = {
+      id: data[3],
+      properties: {
+        id: data[3],
+        [this.props.xVar]: data[0],
+        [this.props.yVar]: data[1],
+        ...this.props.hoveredMetaData
+      },
+    }
+    this.props.onHoverFeature(feature);
+    if (_isEmpty(this.props.hoveredMetaData)) {
+      this.props.loadMetadataForPlace(feature.id)
+    }
+    this.props.onHover && this.props.onHover(data);
+  }, 100);
+
+  _onReady = (echart) => {
+    this.echart = echart;
+  }
+
+  _onHover = (data, e) => {
+    // remove any old hovered features sticking around
+    if(data && data[3]) {
+      this.props.onHoverFeature(null)
+    }
+    // call debounced hover function
+    this._handleHover(data, e);
+  }
+
   render() {
-    const { onHover, onClick } = this.props;
     return (
       <Scatterplot 
-        onHover={onHover}
-        onClick={onClick}
+        onReady={this._onReady}
+        onHover={this._onHover}
+        onClick={this._handleClick}
         options={this.state.options}
       />  
     )
   }
 }
 
-const mapStateToProps = (state, ownProps) => ({
-  series: getScatterplotSeries(state, ownProps)
-});
+const mapStateToProps = (
+  { 
+    scatterplot: { data },
+    hovered: { feature },
+    search: { results },
+    selected
+  }, 
+  { xVar, yVar, zVar = 'sz', region }
+) => { 
+  // map selected IDs to colors
+  const selectedMap = selected[region] && selected.colors ? 
+    selected[region].reduce((acc, curr, i) => ({
+      ...acc,
+      [curr]: selected.colors[i % selected.colors.length]
+    }), {}) : {}
+  return ({
+    series: getScatterplotSeries(data[region], selectedMap, xVar, yVar, zVar),
+    data: data[region],
+    hoveredId: feature && feature.properties && feature.properties.id ?
+      feature.properties.id : null,
+    hoveredFeature: feature ? feature : null,
+    hoveredMetaData: feature && results[feature.properties.id] ? 
+      results[feature.properties.id] : {},
+    selected: selectedMap
+ })
+};
+
+const mapDispatchToProps = (dispatch) => ({
+  onHoverFeature: (feature) =>
+    dispatch(onHoverFeature(feature)),
+  loadMetadataForPlace: (id) =>
+    dispatch(fetchResults(id)),
+  loadVarsForRegion: (vars, region) => 
+    dispatch(loadVarsForRegion(vars, region)),
+  addSelectedLocation: (location) => (
+    dispatch(loadLocation(location))
+  ),
+  updateMapViewport: (feature, meta) =>
+  meta ?
+    dispatch(onViewportChange({ 
+      latitude: parseFloat(meta.lat), 
+      longitude: parseFloat(meta.lon),
+      zoom: feature.id.length+2
+    }, true)) : null
+})
 
 export default connect(
   mapStateToProps, 
-  null
+  mapDispatchToProps,
 )(ConnectedScatterplot)

--- a/src/components/map-view/Map.js
+++ b/src/components/map-view/Map.js
@@ -147,7 +147,7 @@ class Map extends Component {
   }
 
   _onHover = event => {
-    const { features, srcEvent: { offsetX, offsetY } } = event;
+    const { features, srcEvent: { clientX, clientY } } = event;
     const { region } = this.props;
     // find features on the active region
     const hoveredFeature = features && 
@@ -156,7 +156,7 @@ class Map extends Component {
         (region === 'schools' && f.layer.id === 'dots')
       ));
     // set the mouse coords
-    const coords = { x: offsetX, y: offsetY };
+    const coords = { x: clientX, y: clientY };
     // trigger hover feature actions, padding the featue and
     // mouse coordinates
     this.props.onHoverFeature(hoveredFeature, coords);

--- a/src/components/map-view/Map.js
+++ b/src/components/map-view/Map.js
@@ -62,7 +62,7 @@ class Map extends Component {
     selectedIds.forEach((id,i) => {
       const region = getRegionFromId(id);
       this._setFeatureState(
-        region, id, { selected: this.props.colors[i] }
+        region, id, { selected: this.props.colors[i % this.props.colors.length] }
       );
     })
   }

--- a/src/components/map-view/MapScatterplot.js
+++ b/src/components/map-view/MapScatterplot.js
@@ -5,46 +5,22 @@ import { compose } from 'redux';
 import { withRouter } from 'react-router-dom';
 import { scatterOptions } from '../../constants/scatterOptions';
 import { getPaddedMinMax } from '../../modules/metrics';
-import { loadVarsForRegion } from '../../actions/scatterplotActions';
-import { onHoverFeature, onCoordsChange, onViewportChange } from '../../actions/mapActions';
-import { getRegionData } from '../../modules/scatterplot';
-import { getDataScale } from '../../utils';
-import { fetchResults } from '../../actions/searchActions';
-import * as _isEmpty from 'lodash.isempty';
 import Hint from '../base/Hint';
-import { loadLocation } from '../../actions/featuresActions';
 import { fade } from '@material-ui/core/styles/colorManipulator';
 import * as _isEqual from 'lodash.isequal';
 import { getStops } from '../../modules/metrics';
 import ColorStops from './ColorStops';
-import Scatterplot from '../scatterplot/Scatterplot';
 import ConnectedScatterplot from './ConnectedScatterplot';
 
-
-// TODO: refactoring, this component is too big.
-//   Should split into presentational scatterplot component
-//   and pass data to abstact data loading
 export class MapScatterplot extends Component {
   static propTypes = {
     region: PropTypes.string,
     yVar: PropTypes.string,
     xVar: PropTypes.string,
     zVar: PropTypes.string,
-    xData: PropTypes.object,
-    yData: PropTypes.object,
-    zData: PropTypes.object,
-    loadVarsForRegion: PropTypes.func,
     colors: PropTypes.array,
     metric: PropTypes.object,
     yRange: PropTypes.object,
-    hoveredFeature: PropTypes.object,
-    onHoverFeature: PropTypes.func,
-    loadMetadataForPlace: PropTypes.func,
-    hoveredMetaData: PropTypes.object,
-    updateMapViewport: PropTypes.func,
-    addSelectedLocation: PropTypes.func,
-    selectedIds: PropTypes.array,
-    selectedColors: PropTypes.array,
     stops: PropTypes.array,
   }
 
@@ -56,117 +32,20 @@ export class MapScatterplot extends Component {
     }
   }
 
-  _loadScatterplotData() {
-    const { 
-      xVar, 
-      yVar, 
-      zVar, 
-      xData, 
-      yData, 
-      zData, 
-      region, 
-      loadVarsForRegion 
-    } = this.props;
-    const vars = [];
-    zVar && !zData && vars.push(zVar);
-    xVar && !xData && vars.push(xVar);
-    yVar && !yData && vars.push(yVar);
-    loadVarsForRegion(vars, region);
-  }
-
   /**
    * Gets the visual map that is used to color the base dots
    * in the scatterplot
    */
-  _getBaseVisualMapOverrides() {
+  _getVisualMapOverrides() {
     const { colors, metric: {min, max} } = this.props;
-    return {
+    return [{
+      type: 'continuous',
       min,
       max,
       inRange: {
         color: colors.map(c => fade(c, 0.9))
       }
-    }
-  }
-
-  /**
-   * Gets the visual map that is used to color the hover
-   * dot and any selected locations.
-   */
-  _getOverlayVisualMapOverrides() {
-    const { selectedColors, selectedIds } = this.props;
-    return {
-      show: false,
-      type: 'piecewise',
-      dimension: 4,
-      pieces: [
-        { value: -1, color: '#f00' }, // hovered style
-        ...selectedIds.map((id, i) => {
-          return {
-            value: i,
-            color: selectedColors[i]
-          }
-        })
-      ]
-    }
-  }
-
-  /**
-   * Gets the scatterplot data for a given ID
-   * @param {string} id 
-   * @param {number} i optional index to add to the data
-   */
-  _getDataForFeatureId(id, i = -1) {
-    const { xData, yData, zData } = this.props;
-    return xData[id] && yData[id] && zData[id] ?
-      [ xData[id], yData[id], zData[id], id, i ] :
-      [ ]
-  }
-
-  /**
-   * Gets scatterplot data for an list of IDs
-   * @param {Array<string>} ids
-   */
-  _getDataForFeatureIds(ids) {
-    const { xData, yData, zData } = this.props;
-    return xData && yData && zData ?
-      ids.map((id,i) => this._getDataForFeatureId(id, i)) :
-      [ ]
-  }
-
-  /**
-   * Gets the configuration overrides for the overlay scatterplot
-   */
-  _getOverlayOverrides() {
-    const { hoveredFeature, yRange, selectedIds, zData } = this.props;
-    const sizeScale = getDataScale(zData, { range: [5, 40] });
-    return {
-      xAxis: { ...scatterOptions.xAxis, show: false },
-      yAxis: { ...yRange, show: false },
-      visualMap: this._getOverlayVisualMapOverrides(),
-      series: [
-        {
-          type: 'effectScatter',
-          symbolSize: 10,
-          data: hoveredFeature && 
-            hoveredFeature.properties.id ? 
-              [this._getDataForFeatureId(hoveredFeature.properties.id, -1)] : 
-              []
-          ,
-          z: 3
-        },
-        {
-          data: this._getDataForFeatureIds(selectedIds), 
-          symbolSize: (value) => sizeScale(value[2]),
-          itemStyle: {
-            borderWidth: 1.5,
-            borderColor: '#fff',
-            shadowColor: 'rgba(0,0,0,1)',
-            shadowBlur: 2
-          },
-        }
-      ]
-    }
+    }]
   }
 
   /**
@@ -175,81 +54,26 @@ export class MapScatterplot extends Component {
   _getOverrides() {
     const { yRange } = this.props;
     return {
-      visualMap: this._getBaseVisualMapOverrides(),
+      visualMap: this._getVisualMapOverrides(),
       xAxis: scatterOptions.xAxis,
       yAxis: { ...yRange, splitNumber: 7 },
     }
   }
 
-  _handleHover = (data, e) => {
-    if (!data) {
-      return this.props.onHoverFeature(null, {x:0,y:0});
-    }
-    const feature = {
-      id: data[3],
-      properties: {
-        id: data[3],
-        [this.props.xVar]: data[0],
-        [this.props.yVar]: data[1],
-        ...this.props.hoveredMetaData
-      },
-    }
-    // TODO: offsetting y value here to account for the header
-    //    should either set position fixed on tooltip, or account
-    //    for offset of parent container to avoid a hard coded value
-    const coords = {
-      x: e.event.clientX,
-      y: e.event.clientY - 64
-    }
-    this.props.onHoverFeature(feature, coords);
-    if (_isEmpty(this.props.hoveredMetaData)) {
-      this.props.loadMetadataForPlace(feature.id)
-    }
-  }
-
-  _handleClick = () => {
-    const { updateMapViewport, hoveredFeature, hoveredMetaData } = this.props;
-    this.props.addSelectedLocation({
-      id: hoveredMetaData.id,
-      latitude: hoveredMetaData.lat,
-      longitude: hoveredMetaData.lon
-    })
-    updateMapViewport(hoveredFeature, hoveredMetaData)
-  }
-
   componentDidMount() {
-    this._loadScatterplotData();
     this.setState({
       baseScatterplot: this._getOverrides(),
-      overlayScatterplot: this._getOverlayOverrides()
     })
   }
 
   componentDidUpdate(prevProps) {
-    const { region, xVar, yVar, zVar, selectedIds, hoveredFeature } = this.props;
-    if (
-      prevProps.region !== region ||
-      prevProps.xVar !== xVar ||
-      prevProps.zVar !== zVar ||
-      prevProps.yVar !== yVar
-    ) {
-      this._loadScatterplotData();
-    }
     // update scatterplot overrides when metric or range changes
     if (
       !_isEqual(prevProps.metric, this.props.metric) ||
       !_isEqual(prevProps.yRange, this.props.yRange)
     ) {
       this.setState({
-        baseScatterplot: this._getOverrides(),
-        overlayScatterplot: this._getOverlayOverrides()
-      })
-    } else if (
-      !_isEqual(prevProps.hoveredFeature, hoveredFeature) ||
-      !_isEqual(prevProps.selectedIds, selectedIds)
-    ) {
-      this.setState({
-        overlayScatterplot: this._getOverlayOverrides()
+        baseScatterplot: this._getOverrides()
       })
     }
   }
@@ -283,16 +107,7 @@ export class MapScatterplot extends Component {
               zVar={this.props.zVar}
               region={this.props.region}
               options={this.state.baseScatterplot}
-              onHover={this._handleHover.bind(this)}
-              onClick={this._handleClick.bind(this)}
             /> 
-          }
-          { 
-            this.state.overlayScatterplot && 
-            <Scatterplot
-              style={{ pointerEvents: 'none', position: 'absolute', width: '100%', height: '100%' }}
-              options={this.state.overlayScatterplot}
-            />
           }
         </div>
       </div>
@@ -300,6 +115,11 @@ export class MapScatterplot extends Component {
   }
 }
 
+/**
+ * Pads both sides of the provided stops by the given amount
+ * @param {*} stops 
+ * @param {*} amount 
+ */
 const getPaddedStops = (stops, amount) => {
   const targetLength = (stops.length-1) + (amount*2)
   const newStops = [];
@@ -311,61 +131,24 @@ const getPaddedStops = (stops, amount) => {
   return newStops
 }
 
-const mapStateToProps = ({
-  hovered: { feature },
-  scatterplot, 
-  metrics,
-  search: { results },
-  selected
-}, {
-  match: { params: { region, metric, demographic } }
-}) => { 
+const mapStateToProps = (
+  { metrics }, 
+  { match: { params: { region, metric, demographic } } }
+) => { 
   region = (region === 'schools' ? 'districts' : region);
   return ({
     region,
-    demographic,
-    selectedIds: selected[region],
     yVar: demographic + '_' + metric,
-    xData: getRegionData(scatterplot, region, 'all_ses'),
-    yData: getRegionData(scatterplot, region, demographic + '_' + metric),
-    zData: getRegionData(scatterplot, region, 'sz'),
-    yRange: getPaddedMinMax(metrics, metric, 1),
     xVar: 'all_ses',
     zVar: 'sz',
-    stops: getPaddedStops(getStops(metrics, metric), 1), 
-    loadedVars: scatterplot.data[region] ?
-      Object.keys(scatterplot.data[region]) : [],
+    yRange: getPaddedMinMax(metrics, metric, 0),
+    stops: getPaddedStops(getStops(metrics, metric), 0), 
     colors: metrics.colors,
     metric: metrics.items[metric],
-    selectedColors: selected.colors,
-    hoveredFeature: feature ? feature : null,
-    hoveredMetaData: feature && results[feature.properties.id] ? 
-       results[feature.properties.id] : {}
   })
 }
 
-const mapDispatchToProps = (dispatch) => ({
-  addSelectedLocation: (location) => (
-    dispatch(loadLocation(location))
-  ),
-  onHoverFeature: (feature, coords) => (
-    dispatch(onHoverFeature(feature)) &&
-    dispatch(onCoordsChange(coords))
-  ),
-  loadMetadataForPlace: (id) =>
-    dispatch(fetchResults(id)),
-  loadVarsForRegion: (vars, region) => 
-    dispatch(loadVarsForRegion(vars, region)),
-  updateMapViewport: (feature, meta) =>
-    meta ?
-      dispatch(onViewportChange({ 
-        latitude: parseFloat(meta.lat), 
-        longitude: parseFloat(meta.lon),
-        zoom: feature.id.length+2
-      }, true)) : null
-})
-
 export default compose(
   withRouter,
-  connect(mapStateToProps, mapDispatchToProps)
+  connect(mapStateToProps, null)
 )(MapScatterplot)

--- a/src/components/map-view/MapSelectedLocations.js
+++ b/src/components/map-view/MapSelectedLocations.js
@@ -26,7 +26,7 @@ const MapSelectedLocations = ({
               key={s.id}
               number={i+1}
               {...s.properties}
-              color={colors[i]}
+              color={colors[i % colors.length]}
               onLocationClick={() => navigateToLocation(s)}
               onDismissClick={() => removeLocation(s)}
               onReportClick={() => showReportCard(s.properties.id)}

--- a/src/components/scatterplot/Scatterplot.js
+++ b/src/components/scatterplot/Scatterplot.js
@@ -9,13 +9,19 @@ export class Scatterplot extends Component {
     onHover: PropTypes.func,
     onClick: PropTypes.func,
     onReady: PropTypes.func,
+    onMouseMove: PropTypes.func,
     style: PropTypes.object
   }
 
   _onChartReady(e) {
-    e.on('mouseover', (e) => this.props.onHover(e.data, e.event))
-    e.on('mouseout', (e) => this.props.onHover(null, e.event))
-    e.on('click', this.props.onClick)
+    this.props.onHover &&
+      e.on('mouseover', (e) => this.props.onHover(e.data, e.event))
+    this.props.onHover && 
+      e.on('mouseout', (e) => this.props.onHover(null, e.event))
+    this.props.onMouseMove && 
+      e.on('mousemove', (e) => this.props.onMouseMove(e))
+    this.props.onClick && 
+      e.on('click', this.props.onClick)
     this.props.onReady && this.props.onReady(e)
   }
 

--- a/src/components/scatterplot/Scatterplot.js
+++ b/src/components/scatterplot/Scatterplot.js
@@ -8,6 +8,7 @@ export class Scatterplot extends Component {
     options: PropTypes.object,
     onHover: PropTypes.func,
     onClick: PropTypes.func,
+    onReady: PropTypes.func,
     style: PropTypes.object
   }
 
@@ -15,7 +16,7 @@ export class Scatterplot extends Component {
     e.on('mouseover', (e) => this.props.onHover(e.data, e.event))
     e.on('mouseout', (e) => this.props.onHover(null, e.event))
     e.on('click', this.props.onClick)
-    this.echart = e;
+    this.props.onReady && this.props.onReady(e)
   }
 
   render() {

--- a/src/index.css
+++ b/src/index.css
@@ -515,7 +515,7 @@ body {
 /** END COMPONENTS */
 
 .tooltip {
-  position: absolute;
+  position: fixed;
   z-index: 9999;
   margin: 8px;
   padding: 8px;

--- a/src/modules/selected.js
+++ b/src/modules/selected.js
@@ -27,7 +27,8 @@ const createRegionListReducer = (region) =>
   (state = [], action) => {
     switch (action.type) {
       case 'ADD_SELECTED_FEATURE':
-        return (action.region === region || region === 'all') ? 
+        return (action.region === region || region === 'all') &&
+          state.indexOf(action.feature.properties.id) === -1 ? 
           [ ...state, action.feature.properties.id ] : state;
       case 'LOAD_FEATURES_SUCCESS':
         return [

--- a/src/utils/scatterplot.js
+++ b/src/utils/scatterplot.js
@@ -112,12 +112,12 @@ const getContainerOptions = (overrides = {}) =>
  * Merge visual map overrides with default visual map options
  * @param {object} overrides https://ecomfe.github.io/echarts-doc/public/en/option.html#visualMap
  */
-const getVisualMapOptions = (overrides = {}) =>
-  merge(
+const getVisualMapOptions = (overrides = []) =>
+  overrides.map((vm) => merge(
     {},
     visualMapOptions,
-    overrides
-  )
+    vm
+  ))
 
 /**
  * Gets the base scatterplot config with the provided overrides


### PR DESCRIPTION
Closes #50 and shows selected places and hovered areas without resorting to two scatterplots.