### PR TITLE
Scatterplot enhancements

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@material-ui/icons": "^3.0.2",
     "algoliasearch": "^3.32.0",
     "axios": "^0.18.0",
+    "classnames": "^2.2.6",
     "connected-react-router": "4.5.0",
     "d3-ease": "^1.0.5",
     "immutable": "^4.0.0-rc.12",

--- a/src/components/base/DynamicScatterplot.js
+++ b/src/components/base/DynamicScatterplot.js
@@ -57,8 +57,7 @@ const getHighlightedSeries = (isOn) => {
     type: 'scatter',
     show: isOn,
     itemStyle: {
-      borderWidth: 0,
-      borderColor: 'rgba(0,0,0,0)'
+      borderColor: 'rgba(6, 29, 86, 0.4)'
     }
   }
 }
@@ -173,7 +172,10 @@ function DynamicScatterplot({
           zVar={zVar}
           hovered={hovered}
           onReady={onReady}
-          onHover={onHover}
+          onHover={(loc) => loc && loc.id ?
+              onHover({ id: loc.id, properties: loc }) :
+              null
+          }
           onClick={onClick}
           onData={onData}
           data={data}

--- a/src/components/base/DynamicScatterplot.js
+++ b/src/components/base/DynamicScatterplot.js
@@ -57,7 +57,8 @@ const getHighlightedSeries = (isOn) => {
     type: 'scatter',
     show: isOn,
     itemStyle: {
-      borderColor: 'rgba(6, 29, 86, 0.4)',
+      borderWidth: 0,
+      borderColor: 'rgba(0,0,0,0)'
     }
   }
 }
@@ -69,10 +70,30 @@ const getSelectedSeries = (colors = ['#f00']) => {
   return {
     id: 'selected',
     type: 'scatter',
+    label: {
+      show:true,
+      formatter: ({dataIndex}) => {
+        return dataIndex+1
+      },
+      color: '#fff',
+      textBorderColor: 'rgba(6, 29, 86, 1)',
+      textBorderWidth: 3,
+      fontWeight: 'bolder',
+      fontSize: 16,
+      position: 'top',
+      
+    },
+    'emphasis': {
+      label: { textBorderColor: '#f00' }
+    },
     itemStyle: {
       color: ({dataIndex}) => {
         return colors[dataIndex % colors.length]
-      }
+      },
+      borderWidth: 0,
+      borderColor: 'rgba(0,0,0,0)',
+      shadowColor: '#fff',
+      shadowBlur: 1,
     }
   }
 }

--- a/src/components/base/LocationCard.js
+++ b/src/components/base/LocationCard.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { IconButton } from '@material-ui/core';
 import Close from '@material-ui/icons/Close';
 import { getMetricLabel, getDemographicLabel } from '../../modules/config';
 
 function LocationCard({
+  active,
   order, 
   name, 
   state, 
@@ -17,7 +19,12 @@ function LocationCard({
   const data = feature.properties;
   return (
     <div 
-      className='location-card'
+      className={
+        classNames(
+          'location-card', 
+          { 'location-card--active': active }
+        )
+      }
       onMouseEnter={(e) => onHover(feature, e)}
       onMouseLeave={(e) => onHover(null, e)}
       onClick={(e) => onClick(feature, e)}
@@ -66,6 +73,7 @@ function LocationCard({
 
 LocationCard.propTypes = {
   id: PropTypes.string,
+  active: PropTypes.bool,
   name: PropTypes.string,
   state: PropTypes.string,
   metrics: PropTypes.array,

--- a/src/components/base/LocationCards.js
+++ b/src/components/base/LocationCards.js
@@ -8,6 +8,7 @@ function LocationCards({
   children,
   features = [], 
   metrics,
+  hovered,
   onCardDismiss,
   onCardClick,
   onCardHover
@@ -21,6 +22,7 @@ function LocationCards({
               key={'loc' + f.properties.id}
               id={f.properties.id}
               order={i+1}
+              active={f.properties.id === hovered}
               name={f.properties.name}
               state={getStateName(f.properties.id)}
               metrics={metrics}
@@ -38,6 +40,7 @@ function LocationCards({
 
 LocationCards.propTypes = {
   children: PropTypes.node,
+  hovered: PropTypes.string,
   features: PropTypes.array,
   metrics: PropTypes.array,
   onCardClick: PropTypes.func,

--- a/src/components/map/MapLocationCards.js
+++ b/src/components/map/MapLocationCards.js
@@ -7,11 +7,13 @@ import { getLocationFromFeature, parseLocationsString } from '../../modules/rout
 import { onHoverFeature } from '../../actions/mapActions';
 
 const mapStateToProps = (
-  { selected, features },
+  { selected, features, hovered: { feature } },
   { 
     match: { params: { region } } 
   }
 ) => ({
+  hovered: feature && feature.properties && feature.properties.id ?
+    feature.properties.id : null,
   features: selected[region]
     .map(l => 
       features[l] && features[l].properties ? 

--- a/src/components/map/MapScatterplot.js
+++ b/src/components/map/MapScatterplot.js
@@ -31,7 +31,7 @@ export class MapScatterplot extends Component {
     highlightedState: PropTypes.string,
     highlightOn: PropTypes.bool,
     data: PropTypes.object,
-    onHoverFeature: PropTypes.func,
+    onHover: PropTypes.func,
     updateMapViewport: PropTypes.func,
     onSelectLocation: PropTypes.func,
     onMouseMove: PropTypes.func,
@@ -89,18 +89,6 @@ export class MapScatterplot extends Component {
     window.echartInstance = e
     this.props.onLoaded && this.props.onLoaded(e)
   }
-  
-  _onHover = (location) => {
-    if (location && location.id) {
-      const feature = {
-        id: location.id,
-        properties: location,
-      }
-      this.props.onHoverFeature(feature);
-    } else {
-      this.props.onHoverFeature(null);
-    }
-  }
 
   componentDidMount() {
     this.setState({
@@ -139,7 +127,7 @@ export class MapScatterplot extends Component {
               highlightedState={this.props.highlightedState}
               selected={this.props.selected}
               onReady={this._onReady}
-              onHover={this._onHover}
+              onHover={this.props.onHover}
               onClick={this.props.onSelectLocation}
               onData={this.props.onData}
             /> 
@@ -189,7 +177,7 @@ const mapDispatchToProps = (dispatch) => ({
     dispatch(onScatterplotData(data, region)),
   onLoaded: () => 
     dispatch(onScatterplotLoaded('map')),
-  onHoverFeature: (feature) =>
+  onHover: (feature) =>
     dispatch(onHoverFeature(feature)),
   onSelectLocation: (location) => {
     dispatch(loadLocation(location))

--- a/src/components/sections/AchievementGapSection.js
+++ b/src/components/sections/AchievementGapSection.js
@@ -2,17 +2,17 @@ import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { getRegionControl, getGapControl, getHighlightControl, getSecondaryMetricControl, getMetricIdFromVarName } from '../../modules/config';
-import { onScatterplotData, getDispatchForSection } from '../../actions/scatterplotActions';
 import { getDemographicIdFromVarName } from '../../modules/config';
 import LANG from '../../constants/lang.js';
-import ScatterplotSection from './ScatterplotSection';
+import ScatterplotSection, { sectionMapDispatchToProps } from './ScatterplotSection';
 
 const mapStateToProps = (
   { 
-    scatterplot: { data }, 
+    scatterplot: { data, loaded }, 
     selected, 
     map: { usState }, 
-    report: { achievement } 
+    report: { achievement },
+    hovered: { feature }
   },
   { match: { params: { region } } }
 ) => {
@@ -22,7 +22,12 @@ const mapStateToProps = (
     variant: 'ach',
     region,
     data,
+    ready: Boolean(loaded['map']),
     selected: selected && selected[region],
+    hovered: feature && 
+      feature.properties && 
+      feature.properties.id ?
+        feature.properties.id : '',
     highlightedState: usState,
     ...achievement,
     controlText: 'Showing the $1 of $2 vs. average test scores by $3 in $4',
@@ -42,12 +47,8 @@ const mapStateToProps = (
   })
 } 
 
-const mapDispatchToProps = (dispatch, ownProps) => ({
-  onOptionChange: 
-    getDispatchForSection(dispatch, 'achievement', ownProps),
-  onData: (data, region) =>
-    dispatch(onScatterplotData(data, region)),
-})
+const mapDispatchToProps = 
+  sectionMapDispatchToProps('achievement')
 
 export default compose(
   withRouter,

--- a/src/components/sections/OpportunityDifferencesSection.js
+++ b/src/components/sections/OpportunityDifferencesSection.js
@@ -2,15 +2,15 @@ import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { getMetricControl, getDemographicControl, getHighlightControl, getRegionControl } from '../../modules/config';
-import { onScatterplotData, getDispatchForSection } from '../../actions/scatterplotActions';
 import { getDemographicIdFromVarName, getMetricIdFromVarName } from '../../modules/config';
 import LANG from '../../constants/lang.js';
-import ScatterplotSection from './ScatterplotSection';
+import ScatterplotSection, { sectionMapDispatchToProps } from './ScatterplotSection';
 
 const mapStateToProps = (
   { 
-    scatterplot: { data }, 
-    selected, 
+    scatterplot: { data, loaded }, 
+    selected,
+    hovered: { feature },
     map: { usState }, 
     report: { opportunity } 
   },
@@ -23,6 +23,11 @@ const mapStateToProps = (
     region,
     data,
     selected: selected && selected[region],
+    hovered: feature && 
+      feature.properties && 
+      feature.properties.id ?
+        feature.properties.id : '',
+    ready: Boolean(loaded['map']),
     highlightedState: usState,
     ...opportunity,
     controlText: 'Showing $1 for $2 vs. $3 by $4 in $5',
@@ -46,12 +51,8 @@ const mapStateToProps = (
   })
 } 
 
-const mapDispatchToProps = (dispatch, ownProps) => ({
-  onOptionChange: 
-    getDispatchForSection(dispatch, 'opportunity', ownProps),
-  onData: (data, region) =>
-    dispatch(onScatterplotData(data, region)),
-})
+const mapDispatchToProps = 
+  sectionMapDispatchToProps('opportunity')
 
 export default compose(
   withRouter,

--- a/src/components/sections/ScatterplotSection.js
+++ b/src/components/sections/ScatterplotSection.js
@@ -6,6 +6,10 @@ import MapLocationCards from '../map/MapLocationCards';
 import MapSearch from '../map/MapSearch';
 import MenuSentence from '../base/MenuSentence';
 import LANG from '../../constants/lang';
+import { onScatterplotData, onScatterplotLoaded, getDispatchForSection } from '../../actions/scatterplotActions';
+import { onHoverFeature } from '../../actions/mapActions';
+import { loadLocation } from '../../actions/featuresActions';
+
 
 export class ScatterplotSection extends Component {
   static propTypes = {
@@ -25,6 +29,7 @@ export class ScatterplotSection extends Component {
         )
       })
     ),
+    ready: PropTypes.bool,
     region: PropTypes.string,
     xVar: PropTypes.string,
     yVar: PropTypes.string,
@@ -54,6 +59,7 @@ export class ScatterplotSection extends Component {
       onOptionChange, 
       controlText,
       selectedLocationCount,
+      ready = true,
       ...rest 
     } = this.props;
     return (
@@ -114,10 +120,11 @@ export class ScatterplotSection extends Component {
                 onChange={onOptionChange}
               />
             </div>
-
-            <DynamicScatterplot
-              {...rest}
-            />
+            { ready &&
+              <DynamicScatterplot
+                {...rest}
+              />
+            }
           </div>
         </div>
       </div>
@@ -126,3 +133,17 @@ export class ScatterplotSection extends Component {
 }
 
 export default ScatterplotSection
+
+export const sectionMapDispatchToProps = (sectionId) =>
+  (dispatch, ownProps) => ({
+    onOptionChange: 
+      getDispatchForSection(dispatch, sectionId, ownProps),
+    onData: (data, region) =>
+      dispatch(onScatterplotData(data, region)),
+    onReady: () => 
+      dispatch(onScatterplotLoaded(sectionId)),
+    onHover: (feature) =>
+      dispatch(onHoverFeature(feature)),
+    onClick: (location) =>
+      dispatch(loadLocation(location))
+  })

--- a/src/components/sections/SocioeconomicConditionsSection.js
+++ b/src/components/sections/SocioeconomicConditionsSection.js
@@ -2,14 +2,15 @@ import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { getDemographicIdFromVarName, getRegionControl, getMetricControl, getDemographicControl, getHighlightControl, getMetricIdFromVarName } from '../../modules/config';
-import { onScatterplotData, getDispatchForSection } from '../../actions/scatterplotActions';
+
 import LANG from '../../constants/lang.js';
-import ScatterplotSection from './ScatterplotSection';
+import ScatterplotSection, { sectionMapDispatchToProps } from './ScatterplotSection';
 
 const mapStateToProps = (
   { 
-    scatterplot: { data }, 
-    selected, 
+    scatterplot: { data, loaded }, 
+    selected,
+    hovered: { feature },
     map: { usState },
     report: { socioeconomic } 
   },
@@ -21,7 +22,12 @@ const mapStateToProps = (
     variant: 'ses',
     region,
     data,
+    ready: Boolean(loaded['map']),
     selected: selected && selected[region],
+    hovered: feature && 
+      feature.properties && 
+      feature.properties.id ?
+        feature.properties.id : '',
     highlightedState: usState,
     ...socioeconomic,
     controlText: usState ?
@@ -40,12 +46,8 @@ const mapStateToProps = (
   })
 } 
 
-const mapDispatchToProps = (dispatch, ownProps) => ({
-  onOptionChange: 
-    getDispatchForSection(dispatch, 'socioeconomic', ownProps),
-  onData: (data, region) =>
-    dispatch(onScatterplotData(data, region)),
-})
+const mapDispatchToProps = 
+  sectionMapDispatchToProps('socioeconmic')
 
 export default compose(
   withRouter,

--- a/src/css/components/location-card-list.css
+++ b/src/css/components/location-card-list.css
@@ -12,7 +12,3 @@
   transition: flex 0.2s ease-out;
   max-width: 33.333%;
 }
-
-.location-card-list .location-card--active {
-  flex:3;
-}

--- a/src/css/components/location-card.css
+++ b/src/css/components/location-card.css
@@ -38,6 +38,7 @@
   z-index:10;
 }
 
+.location-card.location-card--active,
 .location-card:hover {
   background:#ffe;
   z-index:20;

--- a/src/style/echartTheme.js
+++ b/src/style/echartTheme.js
@@ -41,10 +41,13 @@ export const theme = {
       borderWidth: 1,
       borderColor: 'rgba(6, 29, 86, 0.4)'      
     },
-    'emphasis': { itemStyle: {
-      borderWidth: 2,
-      borderColor: 'rgba(255,0,0,1)'
-    }}
+    'emphasis': { 
+      itemStyle: {
+        borderWidth: 2,
+        borderColor: 'rgba(255,0,0,1)',
+        color: 'rgba(255,0,0,0.6)'
+      }
+    }
   },
 
   toolbox: {


### PR DESCRIPTION
- allow adding locations through bottom scatterplots (closes #87)
- scatterplot / map hover highlights card
- show numbers on scatterplot for corresponding cards (closes #80)
- set loading state of scatterplots to allow proper loading order (closes #73)
