### PR TITLE
Remove dependency on component routes

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -368,40 +368,40 @@ export const navigateToStateByAbbr = (abbr) =>
 /**
  * Update the route and dispatch the event to update metric
  */
-export const onMetricChange = (metric, ownProps) => (dispatch) => {
-  updateRoute(ownProps, { metric })
+export const onMetricChange = (metric) => (dispatch) => {
+  updateRoute({ metric })
   dispatch(setExplorerMetric(metric))
 }
 
 /**
  * Update the route and dispatch the event to update metric
  */
-export const onViewChange = (view, ownProps) => (dispatch) => {
-  updateRoute(ownProps, { view })
+export const onViewChange = (view) => (dispatch) => {
+  updateRoute({ view })
   dispatch(setExplorerView(view))
 }
 
 
-export const onDemographicChange = (demographic, ownProps) =>
+export const onDemographicChange = (demographic) =>
   (dispatch) => {
-    updateRoute(ownProps, { demographic })
+    updateRoute({ demographic })
     dispatch(setExplorerDemographic(demographic))
   }
 
-export const setDemographicAndMetric = (demographic, metric, ownProps) =>
+export const setDemographicAndMetric = (demographic, metric) =>
   (dispatch) => {
-    updateRoute(ownProps, { demographic, metric })
+    updateRoute({ demographic, metric })
     dispatch(setExplorerDemographic(demographic))
     dispatch(setExplorerMetric(metric))
   }
 
-export const onHighlightedStateChange = (stateAbbr, ownProps) => (dispatch) => {
-  updateRoute(ownProps, { highlightedState: stateAbbr })
+export const onHighlightedStateChange = (stateAbbr) => (dispatch) => {
+  updateRoute({ highlightedState: stateAbbr })
   dispatch(setExplorerState(stateAbbr))
   dispatch(navigateToStateByAbbr(stateAbbr))
 }
 
-export const onRouteUpdates = (updates = {}, ownProps) => (dispatch) => {
+export const onRouteUpdates = (updates = {}) => (dispatch) => {
   if (updates.hasOwnProperty('region')) {
     dispatch(setExplorerRegion(updates.region))
   }
@@ -420,14 +420,14 @@ export const onRouteUpdates = (updates = {}, ownProps) => (dispatch) => {
   if (updates.hasOwnProperty('locations')) {
     dispatch(setExplorerLocations(updates.locations))
   }
-  updateRoute(ownProps, updates);
+  updateRoute(updates);
 } 
 
 /**
  * Thunk that updates the region in the route
  * @param {*} region 
  */
-export const onRegionChange = (region, ownProps) => 
+export const onRegionChange = (region) => 
   (dispatch) => {
     const routeUpdates = { region };
     // set demographic to 'all' if switching to schools
@@ -437,7 +437,7 @@ export const onRegionChange = (region, ownProps) =>
     } else {
       routeUpdates['secondary'] = 'ses';
     }
-    updateRoute(ownProps, routeUpdates)
+    updateRoute(routeUpdates)
     dispatch(setExplorerRegion(region))
     dispatch(clearActiveLocation())
   }

--- a/src/components/organisms/DataOptions/DataOptionsDialog.js
+++ b/src/components/organisms/DataOptions/DataOptionsDialog.js
@@ -147,9 +147,9 @@ const mapStateToProps = (
   region, demographic, metric, highlightedState
 });
 
-const mapDispatchToProps = (dispatch, ownProps) => ({
+const mapDispatchToProps = (dispatch) => ({
   onApplySettings: (updates) => {
-    dispatch(onRouteUpdates(updates, ownProps))
+    dispatch(onRouteUpdates(updates))
   }
 })
 

--- a/src/components/organisms/Embed/EmbedDialog.js
+++ b/src/components/organisms/Embed/EmbedDialog.js
@@ -243,7 +243,7 @@ const mapStateToProps = (
   }
 }
 
-const mapDispatchToProps = (dispatch, ownProps) => ({
+const mapDispatchToProps = (dispatch) => ({
   onClose: () => {
     dispatch(toggleEmbedDialog(false))
   }

--- a/src/components/organisms/Map/MapLegend.js
+++ b/src/components/organisms/Map/MapLegend.js
@@ -68,9 +68,7 @@ const MapLegend = ({
     (isGapDemographic(demographic) ? '_GAP' : '')
   const legendMapKey = 'LEGEND_MAP_' + metric + 
     (isGapDemographic(demographic) ? '_GAP_' : '_')
-  // const legendChartKey = 'LEGEND_CHART_' + metric +
-  //   (isGapDemographic(demographic) ? '_GAP' : '')
-  const freeze = (view === 'chart' || (view === 'split' && !isVersus));
+
   return (
     <div className={classNames(
       "map-legend", 
@@ -111,7 +109,7 @@ const MapLegend = ({
 
           { variant === 'chart' &&
             <div className="map-legend__preview">
-              <SedaScatterplotPreview freeze={freeze}>
+              <SedaScatterplotPreview>
                 <SedaLocationMarkers {...{...vars}} />
                 <ScatterplotAxis
                   axis='y'

--- a/src/components/organisms/Map/ZoomToControl.js
+++ b/src/components/organisms/Map/ZoomToControl.js
@@ -22,9 +22,9 @@ ZoomToControl.propTypes = {
   onButtonClick: PropTypes.func,
 }
 
-const mapDispatchToProps = (dispatch, ownProps) => ({
+const mapDispatchToProps = (dispatch) => ({
   onButtonClick: () =>
-    dispatch(onHighlightedStateChange('us', ownProps))
+    dispatch(onHighlightedStateChange('us'))
 })
 
 export default compose(

--- a/src/components/seda/SedaExplorer.js
+++ b/src/components/seda/SedaExplorer.js
@@ -78,6 +78,7 @@ const ExplorerView = ({
   view,
   demographic,
   gapChart,
+  region,
   canRender,
   activeView,
   onMetricChange,
@@ -90,7 +91,7 @@ const ExplorerView = ({
 
   // load locations and flag potential layout change afterwards
   useEffect(() => {
-    loadRouteLocations(locations)
+    loadRouteLocations(locations, region)
       .then(()=> {
         // set map size when locations load
         onLayoutChange('map')
@@ -180,6 +181,7 @@ const mapStateToProps =
     view,
     demographic,
     helpOpen,
+    region,
     locations,
     selected: selected[region],
     locationActive: Boolean(active),
@@ -188,16 +190,16 @@ const mapStateToProps =
       view === 'chart' ? 'left' : 'split'
   })
 
-const mapDispatchToProps = (dispatch, ownProps) => ({
-  loadRouteLocations: (locations) => 
-    dispatch(loadRouteLocations(locations, ownProps.match.params.region)),
+const mapDispatchToProps = (dispatch) => ({
+  loadRouteLocations: (locations, region) => 
+    dispatch(loadRouteLocations(locations, region)),
   loadFlaggedSchools: () =>
     dispatch(loadFlaggedSchools()),
   onLayoutChange: (view) => 
     ['map', 'split'].indexOf(view) > -1 &&
       dispatch(updateMapSize()),
   onMetricChange: (metricId) =>
-    dispatch(onMetricChange(metricId, ownProps))
+    dispatch(onMetricChange(metricId))
   ,
   onToggleGapChart: (visible, demographicId) => {
     dispatch(toggleGapChart(visible, demographicId))

--- a/src/components/seda/SedaHeader.js
+++ b/src/components/seda/SedaHeader.js
@@ -221,18 +221,18 @@ const mapStateToProps = (
   region: ownProps.match.params.region,
 })
 
-const mapDispatchToProps = (dispatch, ownProps) => ({
+const mapDispatchToProps = (dispatch) => ({
   onHelpClick: () => dispatch(toggleHelp()),
   onMenuClick: () => dispatch({
     type: 'TOGGLE_MENU',
     open: true
   }),
   onMetricChange: _debounce((metricId) => {
-    dispatch(onMetricChange(metricId, ownProps));
+    dispatch(onMetricChange(metricId));
   }, 400),
   onViewChange: (view) => {
     const updatedView = view && view.id ? view.id : view
-    dispatch(onViewChange(updatedView, ownProps));
+    dispatch(onViewChange(updatedView));
   }
 })
 

--- a/src/components/seda/SedaLocationPanel.js
+++ b/src/components/seda/SedaLocationPanel.js
@@ -40,7 +40,10 @@ const SedaLocationPanel = ({
   const flags = useMemo(() => 
     getFeatureFlags(active, flagged)
   , [ active, flagged ])
-  const handleHelpClick = (topicId) => onHelpClick(topicId, helpOpen)
+  const handleHelpClick = useMemo(() =>
+    (topicId) => onHelpClick(topicId, helpOpen)
+  // eslint-disable-next-line
+  , [helpOpen])
   return (
     <LocationPanel 
       feature={active} 

--- a/src/components/seda/SedaLocationPanel.js
+++ b/src/components/seda/SedaLocationPanel.js
@@ -89,9 +89,9 @@ const mapStateToProps =
     selected: selected[region]
   })
 
-const mapDispatchToProps = (dispatch, ownProps) => ({
+const mapDispatchToProps = (dispatch) => ({
   onGapClick: (gapId, metricId) => {
-    dispatch(setDemographicAndMetric(gapId, metricId, ownProps))
+    dispatch(setDemographicAndMetric(gapId, metricId))
   },
   clearActiveLocation: () => 
     dispatch(clearActiveLocation()),

--- a/src/components/seda/SedaMap.js
+++ b/src/components/seda/SedaMap.js
@@ -130,7 +130,7 @@ const mapStateToProps = ({
   })
 }
 
-const mapDispatchToProps = (dispatch, ownProps) => ({
+const mapDispatchToProps = (dispatch) => ({
   onHover: (feature, vars, coords) => {
     dispatch(onHoverFeature(feature))
     dispatch(setTooltipVars(vars))
@@ -139,10 +139,10 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
   },
   onViewportChange: (vp, updateRoute = true) => {
     dispatch(onViewportChange(vp))
-    updateRoute && updateViewportRoute(ownProps, vp);
+    updateRoute && updateViewportRoute(vp);
   },
   resetHighlightedState: () => {
-    dispatch(onHighlightedStateChange('us', ownProps))
+    dispatch(onHighlightedStateChange('us'))
   },
   onClick: (feature) => dispatch(
     handleLocationActivation(feature, 'map')

--- a/src/components/seda/SedaMapLegend.js
+++ b/src/components/seda/SedaMapLegend.js
@@ -25,13 +25,13 @@ const mapStateToProps = ({
   })
 }
 
-const mapDispatchToProps = (dispatch, ownProps) => ({
+const mapDispatchToProps = (dispatch) => ({
   onToggleClick: () => {
     dispatch({type: 'TOGGLE_LEGEND_TYPE'})
     dispatch(onMapLegendAction('toggle-legend'))
   },
   onFullClick: () => {
-    dispatch(onViewChange('chart', ownProps))
+    dispatch(onViewChange('chart'))
     dispatch(onMapLegendAction('full-chart'))
   },
   onHelpClick: (helpOpen) => {

--- a/src/components/seda/SedaSearch.js
+++ b/src/components/seda/SedaSearch.js
@@ -8,7 +8,7 @@ import { getRegionFromFeatureId } from '../../modules/config';
 import Search from '../molecules/Search';
 import { getStateAbbrFromName } from '../../constants/statesFips';
 
-const mapDispatchToProps = (dispatch, ownProps) => ({
+const mapDispatchToProps = (dispatch) => ({
   onSuggestionSelected: (hit) => {
     const region = getRegionFromFeatureId(hit.id)
     const state = getStateAbbrFromName(hit.state_name);
@@ -36,7 +36,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
         }, 'search'))
       }
       dispatch(onSearchSelection(hit))
-      dispatch(onRouteUpdates(routeUpdates, ownProps))
+      dispatch(onRouteUpdates(routeUpdates))
     }
   }
 })

--- a/src/modules/router.js
+++ b/src/modules/router.js
@@ -1,7 +1,7 @@
 import * as _debounce from 'lodash.debounce';
 import * as polylabel from 'polylabel';
 import { push } from 'connected-react-router';
-
+import { history } from '../store';
 /**
  * Variables stored in the root, in order
  */
@@ -99,13 +99,15 @@ export const removeLocationFromPathname = (pathname, locationId) => {
  * @param {string} path 
  * @returns {object} e.g. { region: 'counties', metric: 'avg', ... }
  */
-export const getParamsFromPathname = (path, routeVars = DEFAULT_ROUTEVARS) =>
-  path.substring(1, path.length)
+export const getParamsFromPathname = (path, routeVars = DEFAULT_ROUTEVARS) => {
+  return path.substring(1, path.length)
     .split('/')
     .reduce((acc, curr, i) => ({
       ...acc,
       [routeVars[i]]: curr
     }), {})
+}
+
 
 /**
  * Get the route string based on some passed parameters
@@ -162,14 +164,15 @@ const areNewUpdates = (params, updates) => {
  * @param {object} props props from a component connected to the router
  * @param {object} updates an object of route params to update
  */
-export const updateRoute = (props, updates, routeVars) => {
+export const updateRoute = (updates, routeVars) => {
   if (updates && updates['highlightedState']) {
     updates['highlightedState'] = updates['highlightedState'].toLowerCase()
   }
-  const root = props.match.path.split(':')[0].slice(0,-1)
-  areNewUpdates(props.match.params, updates) &&
-    props.history.push(
-      root + getPathnameFromParams(props.match.params, updates, routeVars)
+  const path = window.location.hash.substr(1);
+  const params = getParamsFromPathname(path);
+  areNewUpdates(params, updates) &&
+    history.push(
+      getPathnameFromParams(params, updates, routeVars)
     );
 }
 
@@ -179,7 +182,7 @@ export const updateRoute = (props, updates, routeVars) => {
  * @param {object} props props from a component connected to the router
  * @param {object} vp an object with the updated viewport params
  */
-export const updateViewportRoute = _debounce((props, vp) => {
+export const updateViewportRoute = _debounce((vp) => {
   if (vp.latitude && vp.longitude && vp.zoom) {
     const paramMap = [ 'latitude', 'longitude', 'zoom' ]
     const routeUpdates = [ 'lat', 'lon', 'zoom' ]
@@ -187,7 +190,7 @@ export const updateViewportRoute = _debounce((props, vp) => {
         ...acc, 
         [curr]: Math.round(vp[paramMap[i]] * 100) / 100
       }), {})
-    updateRoute(props, routeUpdates);
+    updateRoute(routeUpdates);
   }
 }, 1000);
 


### PR DESCRIPTION
# Changes
- drops the dependency on component props when updating route
- use the history tool for route updates
- minimize preview scatterplot re-renders