### PR TITLE
fix: turn off large dataset option to prevent bottleneck

### DIFF
--- a/src/components/organisms/Scatterplot/utils.js
+++ b/src/components/organisms/Scatterplot/utils.js
@@ -111,8 +111,6 @@ const getBaseSeries = ({ highlightedState, sizer, variant }) => {
   const hl = isStateHighlighed(highlightedState)
   return getSeries('base', 'scatter', {
     silent: hl || (variant === 'preview'),
-    large: hl,
-    largeThreshold: 0,
     z:5,
     itemStyle: {
       color: hl ? '#e6e6e6' : '#76ced2cc',


### PR DESCRIPTION
fixes issue where selecting a highlighted state can cause a 30+ second delay