### PR TITLE
switch axis for gap demographics on vs chart

### DIFF
--- a/src/modules/explorer/app/selectors/data.js
+++ b/src/modules/explorer/app/selectors/data.js
@@ -162,8 +162,8 @@ const getVersusVarNames = (metric, demographic) => {
     dem2 = 'p'
   }
   return [
-    dem2 + '_' + metric,
     dem1 + '_' + metric,
+    dem2 + '_' + metric,
     demographic + '_sz'
   ]
 }


### PR DESCRIPTION
per sean's request:

> on the left charter, white scores are on the vertical axis and black oh horizontal.  we’d like it the other way, as it is in the current site.