### PR TITLE
Fixes rollup

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -259,6 +259,8 @@
         -moz-osx-font-smoothing: grayscale;
         width: 100%;
         height: 100%;
+        overflow: hidden;
+        min-height: -webkit-fill-available;
       }
       *,
       *::before,
@@ -274,6 +276,8 @@
         font-size: var(--font-size);
         width: 100%;
         height: 100%;
+        overflow: hidden;
+        min-height: -webkit-fill-available;
       }
 
       a {
@@ -353,7 +357,6 @@
         text-align: center;
         /* transition: transform 0.6s ease-in-out 1s; */
         transform: translate3d(0, 0, 0);
-        overflow: auto;
         background-image: linear-gradient(
           -180deg,
           #061d56 3%,
@@ -707,6 +710,7 @@
         position: relative;
         width: 100%;
         height: 100%;
+        overflow: hidden;
       }
 
       .hidden {

--- a/src/css/global.css
+++ b/src/css/global.css
@@ -86,6 +86,16 @@ button span.mapboxgl-ctrl-icon {
   display: block;
 }
 
+/** 
+  HACK: fix map size, overrides the px value set.  
+  keeps the mobile keyboard from shrinking the map
+*/
+@media (max-width: 420px) {
+  .map > div {
+    height: 100% !important;
+  }
+}
+
 /** attribution positioning */
 .map .mapboxgl-ctrl-bottom-right {
   right: 108px;

--- a/src/css/global.css
+++ b/src/css/global.css
@@ -171,7 +171,7 @@ button span.mapboxgl-ctrl-icon {
   font-weight: 300;
   font-size: var(--mini-font-size);
   border: none;
-  height: 40px;
+  height: 36px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/modules/explorer/app/components/SedaApp.js
+++ b/src/modules/explorer/app/components/SedaApp.js
@@ -1,7 +1,11 @@
 import React from 'react'
 import { Page } from '../../../../shared'
 import { SedaHeader } from './header'
-import { makeStyles, useMediaQuery, useTheme } from '@material-ui/core'
+import {
+  makeStyles,
+  useMediaQuery,
+  useTheme
+} from '@material-ui/core'
 import SedaFooter from './footer'
 import { SedaDataLoader } from '../../loader'
 import SedaExplorer from './SedaExplorer'
@@ -15,7 +19,7 @@ const useStyles = makeStyles(theme => ({
     minHeight: 56,
     [theme.breakpoints.down('sm')]: {
       minHeight: 97
-    },
+    }
   },
   root: {
     overflow: 'hidden'
@@ -39,7 +43,7 @@ const SedaApp = () => {
       <SedaMenu />
       <SedaDataLoader />
       <SedaExplorer className={classes.body} />
-      <SedaFooter isMobile={isMobile} />
+      <SedaFooter />
     </Page>
   )
 }

--- a/src/modules/explorer/app/components/footer/SedaFooter.js
+++ b/src/modules/explorer/app/components/footer/SedaFooter.js
@@ -25,6 +25,7 @@ import { useActiveView } from '../../hooks'
 import { EmbedDialog } from '../../../sharing/components/EmbedDialog'
 import { ShareLinkDialog } from '../../../sharing/components/ShareLinkDialog'
 import { SedaHelpButton } from '../../../help'
+import useMobileFooter from '../../hooks/useMobileFooter'
 
 const links = {
   id: 'share',
@@ -60,7 +61,7 @@ const FooterLinks = ({
   links,
   onClick,
   classes = {},
-  isMobile, 
+  isMobile,
   ...props
 }) => (
   <div
@@ -69,11 +70,9 @@ const FooterLinks = ({
       classes.linkCollection
     )}
     {...props}>
-    {
-      !isMobile && (
-        <span className="footer__link-label">{label}</span>
-      )
-    }
+    {!isMobile && (
+      <span className="footer__link-label">{label}</span>
+    )}
     {Boolean(links.length) &&
       links.map((item, i) => (
         <Tooltip
@@ -109,7 +108,7 @@ const useStyles = makeStyles(theme => ({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'stretch',
-    padding: `0 ${theme.spacing(3)}px`,
+    padding: theme.spacing(0, 3),
     position: 'relative',
     zIndex: 1000,
     borderTop: `1px solid`,
@@ -125,9 +124,19 @@ const useStyles = makeStyles(theme => ({
     '& .MuiSvgIcon-root': {
       color: theme.palette.text.secondary
     },
+    '& .button--help': {
+      marginLeft: theme.spacing(2),
+      height: theme.spacing(3.5)
+    },
     [theme.breakpoints.down('sm')]: {
       justifyContent: 'space-between',
-      padding: `0 ${theme.spacing(2)}px`,
+      padding: theme.spacing(0, 2)
+    },
+    // help removed from footer and moved to header at larger resolutions
+    [theme.breakpoints.up('lg')]: {
+      '& .button--help': {
+        display: 'none'
+      }
     }
   },
 
@@ -139,7 +148,8 @@ const useStyles = makeStyles(theme => ({
     display: 'flex',
     alignItems: 'center',
     marginRight: 'auto',
-    marginLeft: theme.spacing(2)
+    marginLeft: theme.spacing(2),
+    [theme.breakpoints.down('xs')]: { display: 'none' }
   },
   links: {
     display: 'flex',
@@ -147,13 +157,14 @@ const useStyles = makeStyles(theme => ({
   }
 }))
 
-const SedaFooter = ({ isMobile }) => {
+const SedaFooter = props => {
   const shareUrl = window.location.href
 
   const [, toggleLinkDialog] = useLinkDialogVisibility()
   const [, toggleEmbedDialog] = useEmbedDialogVisibility()
   const [, , isEmbed] = useActiveView()
   const classes = useStyles()
+  const isMobile = useMobileFooter()
 
   const handleClick = item => {
     switch (item.id) {
@@ -176,30 +187,27 @@ const SedaFooter = ({ isMobile }) => {
           className={clsx('footer__branding', classes.branding)}>
           <StanfordLogo style={{ height: 16, width: 76 }} />
         </div>
-        {
-          !isMobile && (
-            <div
-              className={clsx(
-                'footer__copyright',
-                classes.copyright
-              )}>
-              {copyright}
-            </div>
-          )
-        }
+        <div
+          className={clsx(
+            'footer__copyright',
+            classes.copyright
+          )}>
+          {copyright}
+        </div>
         <div className={clsx('footer__links', classes.links)}>
           <FooterLinks
             label={links.label}
             isMobile={isMobile}
-            links={!isMobile ? links.items : links.items.slice(0, links.items.length - 1)}
+            links={
+              !isMobile
+                ? links.items
+                : links.items.slice(0, links.items.length - 1)
+            }
             onClick={handleClick}
           />
         </div>
-        {
-          !isMobile
-            ? <EmbedDialog />
-            : <SedaHelpButton />
-        }
+        <SedaHelpButton />
+        {!isMobile && <EmbedDialog />}
         <ShareLinkDialog />
       </PageFooter>
     )

--- a/src/modules/explorer/app/components/header/SedaHeaderActions.js
+++ b/src/modules/explorer/app/components/header/SedaHeaderActions.js
@@ -5,23 +5,21 @@ import { SedaHelpButton } from '../../../help'
 import { SedaMenuButton } from '../../../menu'
 import { SedaSearch } from '../../../search'
 import SedaViewControls from './SedaViewControls'
-import useIsMobile from '../../hooks/useIsMobile'
 
-const styles = (theme) => ({
+const styles = theme => ({
   root: {
     display: 'flex',
-    alignItems:  'center',
+    alignItems: 'center',
     flexDirection: 'row',
     [theme.breakpoints.down('sm')]: {
       alignItems: 'unset',
-      flexDirection: 'row-reverse',
-      
+      flexDirection: 'row-reverse'
     },
     [theme.breakpoints.down('sm')]: {
       '& .react-autosuggest__container': {
         borderLeft: '1px solid #E5E5E5',
         position: 'absolute',
-        right:0,
+        right: 0,
         left: 168,
         transition: theme.transitions.create(['left']),
         background: '#fff',
@@ -37,13 +35,12 @@ const styles = (theme) => ({
     marginRight: theme.spacing(2),
     [theme.breakpoints.down('sm')]: {
       width: '100%',
-      marginRight: 0,
-
+      marginRight: 0
     },
     '& fieldset': {
       [theme.breakpoints.down('sm')]: {
-        border: 0,
-      },
+        border: 0
+      }
     }
   },
   viewControls: {
@@ -53,29 +50,29 @@ const styles = (theme) => ({
     }
   },
   helpButton: {
-    marginRight: theme.spacing(2)
+    marginRight: theme.spacing(2),
+    [theme.breakpoints.down('md')]: {
+      display: 'none'
+    }
   }
 })
 
 const SedaHeaderActions = ({ classes, ...props }) => {
   const [, , isEmbed] = useActiveView()
-  const isMobile = useIsMobile()
-  return (!isEmbed &&
-    <div className={classes.root} {...props}>
-      <SedaSearch
-        TextFieldProps={{
-          classes: { root: classes.searchRoot }
-        }}
-        placeholder="find a place"
-      />
-      <SedaViewControls className={classes.viewControls} />
-      {
-        !isMobile && (
-          <SedaHelpButton classes={{ root: classes.helpButton }} />
-        )
-      }
-      <SedaMenuButton />
-    </div>
+  return (
+    !isEmbed && (
+      <div className={classes.root} {...props}>
+        <SedaSearch
+          TextFieldProps={{
+            classes: { root: classes.searchRoot }
+          }}
+          placeholder="find a place"
+        />
+        <SedaViewControls className={classes.viewControls} />
+        <SedaHelpButton classes={{ root: classes.helpButton }} />
+        <SedaMenuButton />
+      </div>
+    )
   )
 }
 

--- a/src/modules/explorer/app/components/header/SedaViewControls.js
+++ b/src/modules/explorer/app/components/header/SedaViewControls.js
@@ -15,14 +15,14 @@ const useStyles = makeStyles(theme => ({
   button: {
     whiteSpace: 'nowrap',
     [theme.breakpoints.down('sm')]: {
-      border:  0,
+      border: 0
     }
   },
   active: {
     color: theme.palette.primary.main,
     background: 'white',
     [theme.breakpoints.down('sm')]: {
-      background: theme.palette.primary.highlight,
+      background: theme.palette.primary.highlight
     },
     '& .icon .filled': {
       opacity: 1
@@ -41,7 +41,7 @@ const SedaViewControls = ({ classes: overrides, ...props }) => {
   const [view, setView] = useActiveView()
   const theme = useTheme()
   const isLargeViewport = useMediaQuery(
-    theme.breakpoints.up('md')
+    theme.breakpoints.up('lg')
   )
   /** no split view button on small viewports */
   const viewButtons = isLargeViewport

--- a/src/modules/explorer/app/constants/site.js
+++ b/src/modules/explorer/app/constants/site.js
@@ -1,5 +1,8 @@
 import LANG from './en'
 
+/** breakpoint where help switches from footer to header */
+export const HELP_BREAKPOINT = 1280
+
 export const FOOTER = {
   branding: {
     url: '#',

--- a/src/modules/explorer/app/hooks/useMobileFooter.js
+++ b/src/modules/explorer/app/hooks/useMobileFooter.js
@@ -1,0 +1,9 @@
+import { useMediaQuery } from '@material-ui/core'
+import { useMemo } from 'react'
+
+export default function useMobileFooter() {
+  const mobile = useMediaQuery('(max-width: 1024px)')
+  return useMemo(() => {
+    return mobile
+  }, [mobile])
+}

--- a/src/modules/explorer/app/hooks/useUiStore.js
+++ b/src/modules/explorer/app/hooks/useUiStore.js
@@ -58,12 +58,18 @@ const [useUiStore] = create(set => ({
 
   // string determining which selection is currently active
   selection: null,
-  setSelection: selection => set({ selection }),
+  setSelection: selection => {
+    set({ selection })
+  },
   // string to determine which filter selection is active
   filterPanel: null,
   setFilterPanel: filterPanel => set({ filterPanel }),
   setViewFromRoute: params => {
-    set({ view: params.view, isEmbed: !!params.embed, embedSecondary: params.secondary.split("+").length > 1 })
+    set({
+      view: params.view,
+      isEmbed: !!params.embed,
+      embedSecondary: params.secondary.split('+').length > 1
+    })
   }
 }))
 

--- a/src/modules/explorer/filters/components/SedaFilterLocation.js
+++ b/src/modules/explorer/filters/components/SedaFilterLocation.js
@@ -68,6 +68,7 @@ const SedaFilterLocation = props => {
         activateSelection={false}
         onSelect={handleLocationSelect}
         onClear={handleLocationClear}
+        clearOnSelected={false}
       />
     </PanelListItem>
   )

--- a/src/modules/explorer/help/SedaHelpButton.js
+++ b/src/modules/explorer/help/SedaHelpButton.js
@@ -1,29 +1,22 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { makeStyles, Button } from '@material-ui/core'
+import { withStyles, Button } from '@material-ui/core'
 import clsx from 'clsx'
 import useHelpVisibility from './useHelpVisibility'
 
-const useStyles = makeStyles(theme => ({
+const styles = theme => ({
   root: {
     borderColor: theme.palette.secondary.main,
-    color: theme.palette.secondary.main,
-    [theme.breakpoints.down('sm')]: {
-      height: "28px",
-    }
+    color: theme.palette.secondary.main
   }
-}))
+})
 
-const SedaHelpButton = ({
-  classes: overrides = {},
-  ...props
-}) => {
-  const classes = useStyles()
+const SedaHelpButton = ({ classes, className, ...props }) => {
   const [, toggleHelp] = useHelpVisibility()
   return (
     <Button
       variant="outlined"
-      className={clsx(classes.root, overrides.root)}
+      className={clsx('button--help', classes.root, className)}
       onClick={toggleHelp}
       {...props}>
       Help
@@ -35,4 +28,4 @@ SedaHelpButton.propTypes = {
   classes: PropTypes.object
 }
 
-export default SedaHelpButton
+export default withStyles(styles)(SedaHelpButton)

--- a/src/modules/explorer/map/SedaMapLegend.js
+++ b/src/modules/explorer/map/SedaMapLegend.js
@@ -21,11 +21,23 @@ import { useMapSize } from '../../map'
 import { useLocationData } from '../location'
 import { withStyles } from '@material-ui/core'
 
-const styles = (theme) => ({
+const styles = theme => ({
   root: {
-    [theme.breakpoints.down('sm')]: {
-      borderRadius:0,
-      boxShadow: `0 1px 0 rgba(0,0,0,0.1)`
+    maxWidth: theme.spacing(60),
+    boxShadow: `0 0 2px rgba(0,0,0,0.3), 0 1px 4px rgba(0,0,0,0.06)`,
+    [theme.breakpoints.down('xs')]: {
+      borderRadius: 0
+    },
+    [theme.breakpoints.up('sm')]: {
+      borderRadius: `0 0 0 3px`
+    },
+    [theme.breakpoints.up('md')]: {
+      borderRadius: theme.shape.borderRadius
+    }
+  },
+  gradient: {
+    [theme.breakpoints.down('xs')]: {
+      maxWidth: 'none'
     }
   }
 })
@@ -81,7 +93,10 @@ const SedaMapLegend = props => {
   /** prefix for the secondary map legend language */
   const secondaryPrefix = 'LEGEND_DESC' + (isGap ? '_GAP' : '')
   /** secondary label for the map legend */
-  const secondary = getPrefixLang(metric, secondaryPrefix, [...dems, region])
+  const secondary = getPrefixLang(metric, secondaryPrefix, [
+    ...dems,
+    region
+  ])
   /** mid point label for the map legend */
   const midLabel = getPrefixLang(
     metric,
@@ -93,7 +108,11 @@ const SedaMapLegend = props => {
   return (
     <MapLegend
       layout={width < 600 ? 'vertical' : 'horizontal'}
-      primary={primary + ' by ' + getPrefixLang(region, 'LABEL_SINGULAR')}
+      primary={
+        primary +
+        ' by ' +
+        getPrefixLang(region, 'LABEL_SINGULAR')
+      }
       secondary={secondary}
       midLabel={midLabel}
       midPosition={midPosition}

--- a/src/modules/explorer/scatterplot/components/SedaScatterplot.js
+++ b/src/modules/explorer/scatterplot/components/SedaScatterplot.js
@@ -36,25 +36,26 @@ const useStyles = makeStyles(theme => ({
     right: theme.spacing(8),
     bottom: theme.spacing(6),
     [theme.breakpoints.down('sm')]: {
-      left:theme.spacing(1),
+      left: theme.spacing(1),
       right: theme.spacing(6)
     }
   },
   // make space for toggle button
   headerOffset: {
     [theme.breakpoints.up('sm')]: {
-    right: 88
+      right: 88
     }
   },
   toggleButton: {
     marginLeft: 0,
     minWidth: 80,
+    maxWidth: 88,
     whiteSpace: 'normal',
     fontSize: theme.typography.pxToRem(12),
     [theme.breakpoints.up('sm')]: {
       position: 'absolute',
       top: -1,
-      right: -88,
+      right: -88
     }
   }
 }))

--- a/src/modules/map/hooks/useMapStore.js
+++ b/src/modules/map/hooks/useMapStore.js
@@ -56,7 +56,8 @@ const [useMapStore] = create((set, get) => ({
   loaded: false,
   resetViewport: { ...DEFAULT_VIEWPORT },
   viewport: DEFAULT_VIEWPORT,
-  setViewport: viewport =>
+  setViewport: viewport => {
+    console.log('set vp', viewport)
     set(state => {
       const newViewport = {
         ...state.viewport,
@@ -65,7 +66,9 @@ const [useMapStore] = create((set, get) => ({
       return {
         viewport: newViewport
       }
-    }),
+    })
+  },
+
   setResetViewport: resetViewport => set({ resetViewport }),
   setLoaded: loaded => set({ loaded }),
   flyToFeature: feature => {

--- a/src/modules/search/components/AutoComplete.js
+++ b/src/modules/search/components/AutoComplete.js
@@ -1,8 +1,46 @@
-import React, { useState, useEffect } from 'react'
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useLayoutEffect
+} from 'react'
 import PropTypes from 'prop-types'
 import { Highlight } from 'react-instantsearch-dom'
 import AutoSuggest from 'react-autosuggest'
 import { SearchInput } from '../../../shared'
+import { Popper } from '@material-ui/core'
+
+var switchToModal = function(data) {
+  console.log('CALLING', data)
+  return data
+}
+
+// const renderSuggestionsContainer = ({
+//   children,
+//   query,
+//   containerProps,
+//   inputRef,
+//   ...props
+// }) => {
+//   const popperRef = useRef(null)
+//   console.log(
+//     children,
+//     containerProps,
+//     inputRef?.current,
+//     popperRef?.current
+//   )
+//   popperRef?.current?.scheduleUpdate()
+//   return (
+//     <Popper
+//       open={query}
+//       ref={popperRef}
+//       placement="bottom"
+//       anchorEl={inputRef?.current?.input}
+//       {...containerProps}>
+//       <div {...props}>{children}</div>
+//     </Popper>
+//   )
+// }
 
 /** Renders the input component for search */
 const renderInputComponent = (
@@ -50,9 +88,14 @@ const AutoComplete = ({
   onSuggestionSelected: onSelected,
   onSelectedClear: onClear,
   value: overrideValue,
+  clearOnSelected = true,
   ...props
 }) => {
   const [value, setValue] = useState(currentRefinement)
+  const [anchorEl, setAnchorEl] = useState(null)
+
+  const inputRef = useRef(null)
+  const popperRef = useRef(null)
 
   const handleChange = event => {
     setValue(event.target.value)
@@ -65,6 +108,7 @@ const AutoComplete = ({
 
   const handleSelected = (event, hit) => {
     onSelected && onSelected(event, hit)
+    if (clearOnSelected) return setValue('')
     const value = [hit.suggestion.name]
     if (hit.suggestion.state_name)
       value.push(hit.suggestion.state_name)
@@ -91,8 +135,13 @@ const AutoComplete = ({
       setValue(overrideValue)
   }, [overrideValue])
 
+  useLayoutEffect(() => {
+    setAnchorEl(inputRef?.current?.input)
+  }, [])
+
   return (
     <AutoSuggest
+      ref={inputRef}
       suggestions={hideSuggestions ? [] : hits}
       multiSection={multiSection}
       inputProps={combinedInputProps}
@@ -110,6 +159,35 @@ const AutoComplete = ({
       }
       renderSectionTitle={renderSectionTitle}
       renderSuggestion={renderSuggestion}
+      renderSuggestionsContainer={options => {
+        console.log(popperRef.current, anchorEl)
+        // if (popperRef.current) popperRef.current.scheduleUpdate()
+        return (
+          <Popper
+            popperRef={popperRef}
+            anchorEl={anchorEl}
+            open={Boolean(options.children)}
+            popperOptions={{
+              onUpdate: switchToModal,
+              modifiers: {
+                applyStyle: {
+                  enabled: true,
+                  fn: switchToModal
+                }
+              }
+            }}
+            {...options.containerProps}>
+            <div
+              style={{
+                width: anchorEl
+                  ? anchorEl.clientWidth
+                  : undefined
+              }}>
+              {options.children}
+            </div>
+          </Popper>
+        )
+      }}
       {...props}
     />
   )

--- a/src/modules/search/components/AutoComplete.js
+++ b/src/modules/search/components/AutoComplete.js
@@ -10,37 +10,23 @@ import AutoSuggest from 'react-autosuggest'
 import { SearchInput } from '../../../shared'
 import { Popper } from '@material-ui/core'
 
-var switchToModal = function(data) {
-  console.log('CALLING', data)
+// calculate the position for the popper
+var calculatePosition = function(data) {
+  const x = data.offsets.reference.left
+  const y =
+    data.offsets.reference.top + data.offsets.reference.height
+  data.styles = {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    'z-index': 9999,
+    transform: `translate3d(${x}px, ${y}px, 0)`,
+    width: data.offsets.reference.width,
+    'max-width': `${window.innerWidth - x}px`,
+    'max-height': `${window.innerHeight - y}px`
+  }
   return data
 }
-
-// const renderSuggestionsContainer = ({
-//   children,
-//   query,
-//   containerProps,
-//   inputRef,
-//   ...props
-// }) => {
-//   const popperRef = useRef(null)
-//   console.log(
-//     children,
-//     containerProps,
-//     inputRef?.current,
-//     popperRef?.current
-//   )
-//   popperRef?.current?.scheduleUpdate()
-//   return (
-//     <Popper
-//       open={query}
-//       ref={popperRef}
-//       placement="bottom"
-//       anchorEl={inputRef?.current?.input}
-//       {...containerProps}>
-//       <div {...props}>{children}</div>
-//     </Popper>
-//   )
-// }
 
 /** Renders the input component for search */
 const renderInputComponent = (
@@ -160,31 +146,21 @@ const AutoComplete = ({
       renderSectionTitle={renderSectionTitle}
       renderSuggestion={renderSuggestion}
       renderSuggestionsContainer={options => {
-        console.log(popperRef.current, anchorEl)
-        // if (popperRef.current) popperRef.current.scheduleUpdate()
         return (
           <Popper
             popperRef={popperRef}
             anchorEl={anchorEl}
             open={Boolean(options.children)}
             popperOptions={{
-              onUpdate: switchToModal,
               modifiers: {
-                applyStyle: {
+                computeStyle: {
                   enabled: true,
-                  fn: switchToModal
+                  fn: calculatePosition
                 }
               }
             }}
             {...options.containerProps}>
-            <div
-              style={{
-                width: anchorEl
-                  ? anchorEl.clientWidth
-                  : undefined
-              }}>
-              {options.children}
-            </div>
+            <div>{options.children}</div>
           </Popper>
         )
       }}

--- a/src/shared/components/Buttons/HintIconButton.js
+++ b/src/shared/components/Buttons/HintIconButton.js
@@ -33,6 +33,8 @@ const HintIconButton = ({
       arrow
       title={title}
       placement={placement}
+      enterTouchDelay={1}
+      leaveTouchDelay={0}
       {...TooltipProps}>
       <IconButton
         className={clsx(classes.button, className)}

--- a/src/shared/components/Page/Page.js
+++ b/src/shared/components/Page/Page.js
@@ -8,7 +8,7 @@ const useStyles = makeStyles(theme => ({
     display: 'flex',
     flexDirection: 'column',
     flexGrow: 1,
-    minHeight: '100vh',
+    minHeight: '100%',
     width: '100%'
   }
 }))

--- a/src/shared/components/Page/PageHeader.js
+++ b/src/shared/components/Page/PageHeader.js
@@ -10,7 +10,8 @@ const useStyles = makeStyles(theme => ({
   root: {
     display: 'flex',
     alignItems: 'center',
-    justifyContent: 'center'
+    justifyContent: 'center',
+    boxShadow: `0px 2px 4px -1px rgba(0,0,0,0.05), 0px 4px 5px 0px rgba(0,0,0,0.04), 0px 1px 5px 0px rgba(0,0,0,0.06)`
   },
   logo: {},
   title: {
@@ -24,7 +25,7 @@ const useStyles = makeStyles(theme => ({
     paddingTop: '0px',
     [theme.breakpoints.down(321)]: {
       alignItems: 'flex-start',
-      paddingTop: theme.spacing(1),
+      paddingTop: theme.spacing(1)
     },
     width: '100%',
     maxWidth: props => props.contentWidth || '100%'

--- a/src/shared/components/Panels/SidePanel/SidePanel.js
+++ b/src/shared/components/Panels/SidePanel/SidePanel.js
@@ -1,6 +1,11 @@
 import React, { useRef } from 'react'
 import PropTypes from 'prop-types'
-import { Paper, makeStyles, useTheme, useMediaQuery } from '@material-ui/core'
+import {
+  Paper,
+  makeStyles,
+  useTheme,
+  useMediaQuery
+} from '@material-ui/core'
 import clsx from 'clsx'
 import { useSpring, animated } from 'react-spring'
 
@@ -19,8 +24,8 @@ const useStyles = makeStyles(theme => ({
     left: 0,
     bottom: 0,
     height: '100%',
-    [theme.breakpoints.down('sm')]: {
-      width: props => '100%'
+    [theme.breakpoints.down('xs')]: {
+      width: '100%'
     }
   },
   panelOpen: {}
@@ -42,9 +47,7 @@ const SidePanel = ({
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
   const panelStyle = useSpring({
     transform: open ? 'translateX(0%)' : 'translateX(-100%)',
-    marginLeft: !isMobile 
-    ? marginLeft ? marginLeft : 0 
-    : 0,
+    marginLeft: !isMobile ? (marginLeft ? marginLeft : 0) : 0,
     onStart: () => {
       if (!panelRef.current) return
       if (open) panelRef.current.style.visibility = 'visible'


### PR DESCRIPTION
# Changes
- clears search locations after selection (fixes #450)
- open search suggestions within a popover component (fixes #409)
- set map size properly so it is not shrunk when soft keyboard opens (fixes #449)
- adjusts header components at various breakpoints to prevent overflow and overlap
- adjusts map legend styles
- fixes app exceeding viewport height (100vh fix)