### PR TITLE
load data sets on demand

### DIFF
--- a/src/modules/explorer/loader/hooks/useDataLoading.js
+++ b/src/modules/explorer/loader/hooks/useDataLoading.js
@@ -10,10 +10,10 @@ export default function useDataLoading() {
     state => [state.loaded, state.loading, state.isLoading],
     shallow
   )
-  const region = useDataOptions(state => state.region)
+  const [region, dataOptionsLoading] = useDataOptions(state => [state.region, state.loading])
   useEffect(() => {
-    loadDataForRegion(region)
-  }, [loadDataForRegion, region])
+    !dataOptionsLoading && loadDataForRegion(region)
+  }, [loadDataForRegion, region, dataOptionsLoading])
   return useMemo(() => {
     return [loading, loaded, isLoading]
   }, [loading, loaded, isLoading])

--- a/src/modules/explorer/routing/hooks/useRouting.js
+++ b/src/modules/explorer/routing/hooks/useRouting.js
@@ -34,8 +34,8 @@ export default () => {
   // get the route params based on current view
   const route = useCurrentRoute()
   // function to set options based on a route string
-  const setDataOptions = useDataOptions(
-    state => state.setOptionsFromRoute
+  const [setDataOptions, setDataOptionsLoading] = useDataOptions(
+    state => [state.setOptionsFromRoute, state.setLoading]
   )
   const addLocationsFromRoute = useAddLocationsByRoute()
 
@@ -108,6 +108,7 @@ export default () => {
           })
         }
       }
+      setDataOptionsLoading(false)
     }
     loadRoute()
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Closes #474. 

Viewable [here](https://epic-gates-547713.netlify.app/#/map/none/districts/avg/min/wb/5.2/40.59/-89.92/). Notice that the app only requests `districts.csv`.

Notes:

- This PR makes use of the `loading` boolean located in the `useDataOptions` store. I'm pretty sure I was able to confirm that this isn't used anywhere else, and it seemed right to treat it as a flag for whether or not route/localStorage data has been taken into account during the app loading process.
- So the way this works is that the `loading` flag is set to `false` after both the hash and local storage have been checked for data. Before this PR the `loading` flag is always true, so I'm not sure what its intended purpose is supposed to be (legacy?). 
- The `useDataLoading` hook subsequently checks that this flag is false before initiating any network requests. This prevents the default region "counties" from being unnecessarily loaded. 
