### PR TITLE
implement slider redesign

### DIFF
--- a/src/modules/explorer/filters/components/SedaFiltersForm.js
+++ b/src/modules/explorer/filters/components/SedaFiltersForm.js
@@ -14,7 +14,7 @@ import { formatInteger } from '../../../../shared/utils'
  * Contains all controls for modifying filters
  */
 const SedaFiltersForm = props => {
-  const { filterResults, totalResults, region } = useAppContext()
+  const { filterResults, totalResults, region, metric: activeMetric } = useAppContext()
 
   // TODO: only show metric sliders that are added
   // const [filterMetrics, setFilterMetrics] = useState([])
@@ -49,7 +49,7 @@ const SedaFiltersForm = props => {
       {region !== 'states' && <SedaFilterLocation />}
       <SedaLimitButtons />
       {availableMetrics.map(metric => (
-        <SedaMetricSlider key={metric} metricId={metric} />
+        <SedaMetricSlider key={metric} metricId={metric} isActive={metric === activeMetric} />
       ))}
       {(region === 'schools' || region === 'districts') && (
         <SedaFilterFlags />

--- a/src/modules/explorer/filters/components/SedaMetricSlider.js
+++ b/src/modules/explorer/filters/components/SedaMetricSlider.js
@@ -33,7 +33,22 @@ const SedaMetricSlider = ({ metricId, ...props }) => {
   const min = defaultValue[0]
   const max = defaultValue[1]
   const step = (max - min) / 20
+  const average = min + (max - min) / 2
   const formatter = getFormatterForVarName(varName)
+  const marks = [
+    {
+      value: min,
+      label: formatter(min)
+    },
+    {
+      value: average,
+      label: "average"
+    },
+    {
+      value: max,
+      label: formatter(max)
+    }
+  ]
   const handleSliderChange = useCallback(
     (event, value) => {
       value = value.map(v => parseFloat(v))
@@ -51,13 +66,15 @@ const SedaMetricSlider = ({ metricId, ...props }) => {
       titleProps={{ id: metricId + '-slider' }}
       {...props}>
       <Slider
+        metric={metricId}
+        marks={marks}
+        valueLabelDisplay="auto"
         value={value}
         defaultValue={defaultValue}
         min={min}
         max={max}
         step={step}
         onChange={handleSliderChange}
-        valueLabelDisplay="on"
         aria-labelledby={metricId + '-slider'}
         getAriaValueText={formatter}
         valueLabelFormat={formatter}

--- a/src/modules/explorer/filters/components/SedaMetricSlider.js
+++ b/src/modules/explorer/filters/components/SedaMetricSlider.js
@@ -10,6 +10,17 @@ import { DebouncedSlider as Slider } from '../../../../shared'
 import { getPrefixLang } from '../../app/selectors/lang'
 import { getFormatterForVarName } from '../../app/selectors'
 import useActiveFilters from '../hooks/useActiveFilters'
+import { Tooltip, withStyles } from '@material-ui/core'
+
+const ValueLabelComponent = (props) => {
+  const { children, open, value } = props;
+
+  return (
+    <Tooltip open={open} enterTouchDelay={0} placement="top" arrow title={value}>
+      {children}
+    </Tooltip>
+  );
+}
 
 const getDefaultValue = (region, metric) => {
   const vals = DEFAULT_RANGES[region]
@@ -17,7 +28,7 @@ const getDefaultValue = (region, metric) => {
   return vals[metric]
 }
 
-const SedaMetricSlider = ({ metricId, ...props }) => {
+const SedaMetricSlider = ({ metricId, classes, isActive, ...props }) => {
   // grab filters array
   const filters = useActiveFilters()
   // function to remove a single filter
@@ -66,7 +77,7 @@ const SedaMetricSlider = ({ metricId, ...props }) => {
       titleProps={{ id: metricId + '-slider' }}
       {...props}>
       <Slider
-        metric={metricId}
+        ValueLabelComponent={ValueLabelComponent}
         marks={marks}
         valueLabelDisplay="auto"
         value={value}
@@ -78,6 +89,7 @@ const SedaMetricSlider = ({ metricId, ...props }) => {
         aria-labelledby={metricId + '-slider'}
         getAriaValueText={formatter}
         valueLabelFormat={formatter}
+        classes={classes}
       />
     </PanelListItem>
   )
@@ -85,4 +97,49 @@ const SedaMetricSlider = ({ metricId, ...props }) => {
 
 SedaMetricSlider.propTypes = {}
 
-export default SedaMetricSlider
+export default withStyles(theme => ({
+  root: {
+    padding: '10px 0',
+    position: 'relative'
+  },
+  thumb: {
+    height: 12,
+    width: 6,
+    marginTop: -2,
+    marginLeft: -3,
+    border: '0.5px solid #757575',
+    background: 'white',
+    borderRadius: 2,
+    '&:focus, &:hover, &$active': {
+      height: 14,
+      marginTop: -3,
+      borderColor: 'currentColor',
+      boxShadow: 'inherit'
+    },
+  },
+  track: {
+    height: 8,
+    background: props => !props.isActive ? 'currentColor' : 'fixed linear-gradient(90deg, #1C4E81 100px, #3A7BBB 139px, #7CB4DC 178px, #C0E1EC 217px, #F5F6F7 256px, #D6EECA 295px, #9FDCA3 334px, #32A877 373px, #1B704D 412px)',
+    [theme.breakpoints.down('sm')]: {
+      background: props => !props.isActive ? 'currentColor' : 'fixed linear-gradient(90deg, #1C4E81 20px, #3A7BBB 59px, #7CB4DC 98px, #C0E1EC 137px, #F5F6F7 176px, #D6EECA 215px, #9FDCA3 254px, #32A877 293px, #1B704D 332px)',
+    }
+  },
+  rail: {
+    height: 8,
+    background: '#E0E0E0',
+    opacity: 1
+  },
+  mark: {
+    height: 5,
+    width: 1,
+    backgroundColor: '#E0E0E0',
+    marginTop: 13
+  },
+  markLabel: {
+    color: '#5D5D5D',
+    marginTop: 2,
+    [theme.breakpoints.down('sm')]: {
+      top: 26
+    }
+  },
+}))(SedaMetricSlider)

--- a/src/shared/components/Inputs/Slider.js
+++ b/src/shared/components/Inputs/Slider.js
@@ -1,72 +1,50 @@
 import React, { useState, useRef } from 'react'
 import {
   withStyles,
-  Slider as MuiSlider,
-  Tooltip
+  Slider as MuiSlider
 } from '@material-ui/core'
 import * as _debounce from 'lodash.debounce'
 import useDidUpdateEffect from '../../hooks/useDidUpdateEffect'
 import shallow from 'zustand/shallow'
 import usePrevious from '../../hooks/usePrevious'
 
-const StyledSlider = withStyles(theme => ({
+const StyledSlider = withStyles({
   root: {
     height: 2,
-    padding: '10px 0',
-    position: 'relative'
+    padding: '16px 0'
   },
   thumb: {
-    height: 12,
-    width: 6,
-    marginTop: -2,
-    marginLeft: -3,
-    border: '0.5px solid #757575',
-    background: 'white',
-    borderRadius: 2,
-    '&:focus, &:hover, &$active': {
-      height: 14,
-      marginTop: -3,
-      borderColor: 'currentColor',
-      boxShadow: 'inherit'
-    },
+    height: 16,
+    width: 16,
+    marginTop: -8,
+    marginLeft: -8
   },
   active: {},
-  track: {
-    height: 8,
-    background: (props) => props.metric === 'ses' ? 'currentColor' : 'fixed linear-gradient(90deg, #1C4E81 100px, #3A7BBB 139px, #7CB4DC 178px, #C0E1EC 217px, #F5F6F7 256px, #D6EECA 295px, #9FDCA3 334px, #32A877 373px, #1B704D 412px)',
-    [theme.breakpoints.down('sm')]: {
-      background: (props) => props.metric === 'ses' ? 'currentColor' : 'fixed linear-gradient(90deg, #1C4E81 20px, #3A7BBB 59px, #7CB4DC 98px, #C0E1EC 137px, #F5F6F7 176px, #D6EECA 215px, #9FDCA3 254px, #32A877 293px, #1B704D 332px)',
+  valueLabel: {
+    left: 'calc(-50%)',
+    top: 22,
+    '& *': {
+      background: 'transparent',
+      color: '#000'
     }
+  },
+  track: {
+    height: 2
   },
   rail: {
-    height: 8,
-    background: '#E0E0E0',
-    opacity: 1
+    height: 2,
+    opacity: 0.5
   },
   mark: {
-    height: 5,
+    height: 8,
     width: 1,
-    backgroundColor: '#E0E0E0',
-    marginTop: 13
+    marginTop: -3
   },
-  markLabel: {
-    color: '#5D5D5D',
-    marginTop: 2,
-    [theme.breakpoints.down('sm')]: {
-      top: 26
-    }
-  },
-}))(MuiSlider)
-
-const ValueLabelComponent = (props) => {
-  const { children, open, value } = props;
-
-  return (
-    <Tooltip open={open} enterTouchDelay={0} placement="top" arrow title={value}>
-      {children}
-    </Tooltip>
-  );
-}
+  markActive: {
+    opacity: 1,
+    backgroundColor: 'currentColor'
+  }
+})(MuiSlider)
 
 /**
  * Gets the value for the slider, or provides the default value if none is given
@@ -129,7 +107,6 @@ export function DebouncedSlider({
   }
   return (
     <StyledSlider
-      ValueLabelComponent={ValueLabelComponent}
       value={value}
       onChange={handleChange}
       {...props}

--- a/src/shared/components/Inputs/Slider.js
+++ b/src/shared/components/Inputs/Slider.js
@@ -1,50 +1,72 @@
 import React, { useState, useRef } from 'react'
 import {
   withStyles,
-  Slider as MuiSlider
+  Slider as MuiSlider,
+  Tooltip
 } from '@material-ui/core'
 import * as _debounce from 'lodash.debounce'
 import useDidUpdateEffect from '../../hooks/useDidUpdateEffect'
 import shallow from 'zustand/shallow'
 import usePrevious from '../../hooks/usePrevious'
 
-const StyledSlider = withStyles({
+const StyledSlider = withStyles(theme => ({
   root: {
     height: 2,
-    padding: '16px 0'
+    padding: '10px 0',
+    position: 'relative'
   },
   thumb: {
-    height: 16,
-    width: 16,
-    marginTop: -8,
-    marginLeft: -8
+    height: 12,
+    width: 6,
+    marginTop: -2,
+    marginLeft: -3,
+    border: '0.5px solid #757575',
+    background: 'white',
+    borderRadius: 2,
+    '&:focus, &:hover, &$active': {
+      height: 14,
+      marginTop: -3,
+      borderColor: 'currentColor',
+      boxShadow: 'inherit'
+    },
   },
   active: {},
-  valueLabel: {
-    left: 'calc(-50%)',
-    top: 22,
-    '& *': {
-      background: 'transparent',
-      color: '#000'
+  track: {
+    height: 8,
+    background: (props) => props.metric === 'ses' ? 'currentColor' : 'fixed linear-gradient(90deg, #1C4E81 100px, #3A7BBB 139px, #7CB4DC 178px, #C0E1EC 217px, #F5F6F7 256px, #D6EECA 295px, #9FDCA3 334px, #32A877 373px, #1B704D 412px)',
+    [theme.breakpoints.down('sm')]: {
+      background: (props) => props.metric === 'ses' ? 'currentColor' : 'fixed linear-gradient(90deg, #1C4E81 20px, #3A7BBB 59px, #7CB4DC 98px, #C0E1EC 137px, #F5F6F7 176px, #D6EECA 215px, #9FDCA3 254px, #32A877 293px, #1B704D 332px)',
     }
   },
-  track: {
-    height: 2
-  },
   rail: {
-    height: 2,
-    opacity: 0.5
+    height: 8,
+    background: '#E0E0E0',
+    opacity: 1
   },
   mark: {
-    height: 8,
+    height: 5,
     width: 1,
-    marginTop: -3
+    backgroundColor: '#E0E0E0',
+    marginTop: 13
   },
-  markActive: {
-    opacity: 1,
-    backgroundColor: 'currentColor'
-  }
-})(MuiSlider)
+  markLabel: {
+    color: '#5D5D5D',
+    marginTop: 2,
+    [theme.breakpoints.down('sm')]: {
+      top: 26
+    }
+  },
+}))(MuiSlider)
+
+const ValueLabelComponent = (props) => {
+  const { children, open, value } = props;
+
+  return (
+    <Tooltip open={open} enterTouchDelay={0} placement="top" arrow title={value}>
+      {children}
+    </Tooltip>
+  );
+}
 
 /**
  * Gets the value for the slider, or provides the default value if none is given
@@ -107,6 +129,7 @@ export function DebouncedSlider({
   }
   return (
     <StyledSlider
+      ValueLabelComponent={ValueLabelComponent}
       value={value}
       onChange={handleChange}
       {...props}


### PR DESCRIPTION
Closes #438.

Viewable [here](https://trusting-swirles-f53b8b.netlify.app/).

Notes:

- I'm a little disappointed in the implementation of the gradient – namely it just feels hacky to use pixel values for the color-stops. I tried using percentages but it seemed like there was no way for the percentages to be understood in terms of the parent element's sizing (even though root is styled `position: relative`. If you have any ideas to that end lmk.
- As always please tell me if something should/shouldn't be passed as a prop, if there's an easier way to do things using material-ui stuff I don't know about, etc. 