### PR TITLE
Fix/489

### DIFF
--- a/src/modules/explorer/app/selectors/data.js
+++ b/src/modules/explorer/app/selectors/data.js
@@ -138,7 +138,7 @@ const getSecondaryVarName = (secondary, demographic) => {
   // use "all" SES option for the following demographics
   if (secondary === 'ses') {
     const useAll =
-      ['m', 'f', 'p', 'np', 'a'].indexOf(demographic) > -1
+      ['m', 'f', 'p', 'np'].indexOf(demographic) > -1
     return useAll ? 'all_ses' : demographic + '_ses'
   }
   return demographic + '_' + secondary

--- a/src/modules/explorer/compare/components/CompareTable.js
+++ b/src/modules/explorer/compare/components/CompareTable.js
@@ -8,7 +8,7 @@ import {
   withStyles
 } from '@material-ui/core'
 import { SedaLocationName } from '../../location'
-import { getLang, getPrefixLang } from '../../app/selectors/lang'
+import { getPrefixLang } from '../../app/selectors/lang'
 import { useRegion } from '../../app/hooks'
 import SedaStat from '../../stats/SedaStat'
 import useCompareStore from '../hooks/useCompareStore'
@@ -73,7 +73,7 @@ const TableHeaderMetric = withStyles(theme => ({
     marginTop: 2,
     lineHeight: 1.43
   }
-}))(({ column, classes, children, ...rest }) => {
+}))(({ column, classes, children }) => {
   const demographic = useCompareStore(state => state.demographic, shallow)
   const demographicProps = isGapDemographic(demographic) ? {
     gap: getPrefixLang(demographic, 'LABEL')

--- a/src/modules/explorer/scatterplot/selectors.js
+++ b/src/modules/explorer/scatterplot/selectors.js
@@ -62,11 +62,11 @@ export const getDataExtent = (data, accessor) => {
  * Pads a provided extent
  */
 export const getPaddedExtent = (extent, amount = 0.1) => {
-  const padding = (extent[1] - extent[0]) * amount
+  const padding = (parseFloat(extent[1]) - parseFloat(extent[0])) * amount
   // const interval = getIntervalForExtent(extent)
   const extendedExtent = [
-    extent[0] - padding,
-    extent[1] + padding
+    parseFloat(extent[0]) - padding,
+    parseFloat(extent[1]) + padding
   ]
   return extendedExtent
 }

--- a/src/modules/explorer/scatterplot/selectors.js
+++ b/src/modules/explorer/scatterplot/selectors.js
@@ -52,7 +52,7 @@ export const getDotSizeScale = ({
 
 export const getDataExtent = (data, accessor) => {
   if (typeof accessor === 'string')
-    return d3array.extent(data, d => d[accessor])
+    return d3array.extent(data, d => parseFloat(d[accessor]))
   if (typeof accessor === 'function')
     return d3array.extent(data, accessor)
   throw new Error('invalid accessor to retrieve extent')
@@ -62,11 +62,11 @@ export const getDataExtent = (data, accessor) => {
  * Pads a provided extent
  */
 export const getPaddedExtent = (extent, amount = 0.1) => {
-  const padding = (parseFloat(extent[1]) - parseFloat(extent[0])) * amount
+  const padding = (extent[1] - extent[0]) * amount
   // const interval = getIntervalForExtent(extent)
   const extendedExtent = [
-    parseFloat(extent[0]) - padding,
-    parseFloat(extent[1]) + padding
+    extent[0] - padding,
+    extent[1] + padding
   ]
   return extendedExtent
 }


### PR DESCRIPTION
Fixes #489, adjusting the socioeconomic status subtitle/values in the comparison table as well as the x-axis on certain primary and secondary charts.

Viewable [here](https://compassionate-feynman-49dcdf.netlify.app/).

Notes:

- I noticed something weird going on with the secondary chart for the White-Hispanic gap – the "no gap" line is not appearing in the right place. Obviously it should be on the left side, before +1. Pretty sure there's no way this PR introduces the bug, so I'll do some snooping and see if I can find where it cropped up. 

![image](https://user-images.githubusercontent.com/1114157/106322187-75959400-6243-11eb-8a2d-3ad7ad65c1fe.png)

- This PR introduces two new functions `getSesHintFromDemographic` and `getAccessor` that handle the ways SES behaves differently depending on demographics. They live in `CompareTable.js` right now but I can move them wherever works best. 
- The logic in `getAccessor` is very similar to `getSecondaryVarName` in `app/selectors/data`, but differs in that it only makes male and female demographics use `all_ses`, while poor and non poor continue using their own ses values that return N/A

QA Criteria from @Lane:
> 
> # Compare Dialog
> under socioeconomic status table header, for subgroups:
> 
> * all, male, or female: Average SES among all families in the community
> * white, black, hispanic, asian, or native american: Average SES among all `{{SUBGROUP}}`  families in the community
> * poor or non-poor: Average SES not available for `{{SUBGROUP}}` families
> * gaps (except for poor - non-poor): Average `{{GAP}}` gap SES in the community
> * poor - non-poor gap: Average `{{GAP}}` gap in SES not available
> 
> the values in the table should correspond to the label, e.g:
> 
> * all, male, or female: uses `all_ses` value
> * white, black, hispanic, asian, or native american uses `{{SUBGROUP}}_ses` value (e.g. `w_ses` for white SES)
> * poor or non-poor show "N/A" for all locations (if you use `p_ses` and `np_ses` it should show "N/A" because those values are not available)
> * gaps show gap value where avaialble `{{GAP}}_ses` (e.g. `wb_ses` for white - Black SES)
> * gaps with no SES value (eg. poor - non-poor) show "N/A"
> 
> # Chart Axis
> * all, poor, non-poor, male, or female: "Average families' socioeconomic status"
> * white, black, hispanic, asian, or native american: "`{{SUBGROUP}}` Families' Socioeconomic Status"
> * gaps: "`{{GAP}}` Gap in Socioeconomic Status"
