### PR TITLE
add flag for regular schools, revert radio buttons

### DIFF
--- a/src/modules/data/useStaticData.js
+++ b/src/modules/data/useStaticData.js
@@ -161,6 +161,10 @@ const shapeData = (data, dataSetId) => {
   if (!SHOW_PUERTO_RICO) {
     filteredData = filteredData.filter(d => d.id.substr(0,2) !== '72')
   }
+  // add a flag for "regular" schools: non-magnet, non-charter, non-bie
+  if(dataSetId === "schools") {
+    filteredData = filteredData.map(d => ({...d, rg: !!d.bie || !!d.ch || !!d.mg ? null : 1}))
+  }
   // sort data by number of students (`all_sz`)
   filteredData.sort((a, b) => b['all_sz'] - a['all_sz'])
   // HACK: rename `np_seg` to `pn_seg`, as it is a gap variable (not non-poor)

--- a/src/modules/explorer/app/constants/flags.js
+++ b/src/modules/explorer/app/constants/flags.js
@@ -5,23 +5,16 @@ export const FILTER_FLAGS = {
   states: [],
   counties: [],
   districts: [['r', 't', 's', 'u']],
-  schools: [['r', 't', 's', 'u'], ['m', 'e', 'c']]
-}
-
-export const FILTER_RADIOS = {
-  states: [],
-  counties: [],
-  districts: [],
-  schools: [['ch', 'mg']]
+  schools: [['r', 't', 's', 'u'], ['rg', 'ch', 'mg'], ['m', 'e', 'c']]
 }
 
 // these flags only show locations with corresponding flags when active
 // not currently in use, but was used for BIE filter, and left in incase
 // the functionality is required in the future
-export const EXCLUSIVE_FLAGS = ['ch', 'mg']
+export const EXCLUSIVE_FLAGS = []
 
 // add BIE filter to embargoed
 if (process.env.REACT_APP_EMBARGOED === '1') {
-  FILTER_RADIOS['schools'][0].push('bie')
+  FILTER_FLAGS['schools'].push(['bie'])
   EXCLUSIVE_FLAGS.push('bie')
 }

--- a/src/modules/explorer/app/constants/flags.js
+++ b/src/modules/explorer/app/constants/flags.js
@@ -15,6 +15,5 @@ export const EXCLUSIVE_FLAGS = []
 
 // add BIE filter to embargoed
 if (process.env.REACT_APP_EMBARGOED === '1') {
-  FILTER_FLAGS['schools'].push(['bie'])
-  EXCLUSIVE_FLAGS.push('bie')
+  FILTER_FLAGS['schools'][1].push(['bie'])
 }

--- a/src/modules/explorer/filters/components/SedaFilterFlags.js
+++ b/src/modules/explorer/filters/components/SedaFilterFlags.js
@@ -40,8 +40,7 @@ const makeCheckboxes = (flags, checked) => {
 const GROUP_TITLES = [
   getLang('FLAG_LABEL_AREA'),
   getLang('FLAG_LABEL_SCHOOL'),
-  getLang('FLAG_LABEL_AGE'),
-  getLang('FLAG_LABEL_BIE_GROUP')
+  getLang('FLAG_LABEL_AGE')
 ]
 
 /**

--- a/src/modules/explorer/filters/components/SedaFilterFlags.js
+++ b/src/modules/explorer/filters/components/SedaFilterFlags.js
@@ -4,8 +4,7 @@ import { CheckboxGroup } from '../../../../shared/components/Inputs/Checkboxes'
 import { useRegion } from '../../app/hooks'
 import {
   EXCLUSIVE_FLAGS,
-  FILTER_FLAGS,
-  FILTER_RADIOS
+  FILTER_FLAGS
 } from '../../app/constants/flags'
 import { PanelListItem } from '../../../../shared/components/Panels/PanelList'
 import { getLang, getPrefixLang } from '../../app/selectors/lang'
@@ -13,10 +12,7 @@ import useActiveFilters from '../hooks/useActiveFilters'
 import useFilterStore from '../../../filters'
 import {
   FormControl,
-  FormControlLabel,
   FormLabel,
-  Radio,
-  RadioGroup,
   withStyles
 } from '@material-ui/core'
 import { hasFilterRule } from '../../../filters/useFilterStore'
@@ -41,17 +37,11 @@ const makeCheckboxes = (flags, checked) => {
   }))
 }
 
-const makeRadioButtons = (flags) => {
-  return flags.map((flag, i) => ({
-    id: flag,
-    label: getPrefixLang(flag !== 'bie' ? flag : flag + '_group', 'FLAG_LABEL'),
-  }))
-}
-
 const GROUP_TITLES = [
   getLang('FLAG_LABEL_AREA'),
+  getLang('FLAG_LABEL_SCHOOL'),
   getLang('FLAG_LABEL_AGE'),
-  getLang('FLAG_LABEL_SCHOOL')
+  getLang('FLAG_LABEL_BIE_GROUP')
 ]
 
 /**
@@ -83,7 +73,6 @@ const SedaFilterFlags = ({ classes, className, ...props }) => {
   const [region] = useRegion()
 
   const regionFlags = FILTER_FLAGS[region]
-  const regionRadios = FILTER_RADIOS[region]
 
   // grab filters array
   const filters = useActiveFilters()
@@ -97,14 +86,6 @@ const SedaFilterFlags = ({ classes, className, ...props }) => {
   const checkedFlags = regionFlags
     .flat()
     .filter(f => uncheckedFlags.indexOf(f) === -1)
-  // get active exclusive radio selection
-  const checkedRadio = regionRadios
-    .flat()
-    .filter(flag => hasFilterRule(filters, ['eq', flag, 1])).length > 0 
-    ? regionRadios
-    .flat()
-    .filter(flag => hasFilterRule(filters, ['eq', flag, 1]))[0] 
-    : 'all'
   // function to set (add or update) single filter
   const setFilter = useFilterStore(state => state.setFilter)
   // get checkbox group from flags and active filters
@@ -133,16 +114,6 @@ const SedaFilterFlags = ({ classes, className, ...props }) => {
       : removeFilter(['neq', key], true)
   }
 
-  const radioGroups = useMemo(() => {
-    return regionRadios.map(flagGroup => makeRadioButtons(['all', ...flagGroup]))
-  }, [regionRadios])
-
-  const handleRadioChange = (event, radio) => {
-    console.log("radio:", radio, event)
-    checkedRadio !== 'all' && removeFilter(['eq', checkedRadio], true)
-    radio !== 'all' && setFilter(['eq', radio, 1])
-  }
-
   return (
     <PanelListItem
       className={clsx(classes.root, className)}
@@ -161,23 +132,6 @@ const SedaFilterFlags = ({ classes, className, ...props }) => {
             checkboxes={group}
             onChange={handleCheckboxChange}
           />
-        </FormControl>
-      ))}
-      {regionRadios.length > 0 && radioGroups.map((group, i) => (
-        <FormControl
-        className={classes.group}
-        key={checkboxGroups.length + i}
-        component="fieldset">
-          <FormLabel
-            className={classes.label}
-            component="legend">
-            {GROUP_TITLES[checkboxGroups.length + i]}
-          </FormLabel>
-          <RadioGroup aria-label="school type" value={checkedRadio} onChange={handleRadioChange}>
-            {group.map(({id, label}, i) => (
-              <FormControlLabel value={id} key={i} control={<Radio color='primary' />} label={label} />
-            ))}
-          </RadioGroup>
         </FormControl>
       ))}
     </PanelListItem>

--- a/src/modules/explorer/filters/hooks/useActiveFilters.js
+++ b/src/modules/explorer/filters/hooks/useActiveFilters.js
@@ -1,6 +1,6 @@
 import useFilters from './useFilters'
 import { useRegion } from '../../app/hooks'
-import { FILTER_FLAGS, FILTER_RADIOS } from '../../app/constants/flags'
+import { FILTER_FLAGS } from '../../app/constants/flags'
 import { useMemo } from 'react'
 import { getFilterValue } from '../../../filters/useFilterStore'
 
@@ -11,7 +11,7 @@ export default () => {
   const filters = useFilters()
   const [region] = useRegion()
   return useMemo(() => {
-    const flags = [...FILTER_FLAGS[region].flat(), ...FILTER_RADIOS[region].flat()]
+    const flags = FILTER_FLAGS[region].flat()
     const locationId = getFilterValue(filters, [
       'startsWith',
       'id'

--- a/src/modules/explorer/routing/selectors.js
+++ b/src/modules/explorer/routing/selectors.js
@@ -76,9 +76,10 @@ export const ruleParamToArray = rule => {
     case 'm':
     case 'e':
     case 'c':
-      return ['neq', type, 1]
     case 'ch':
     case 'mg':
+    case 'rg':
+      return ['neq', type, 1]
     case 'bie':
       return ['eq', type, 1]
     case 'limit':
@@ -124,7 +125,7 @@ export const paramsToFilterArray = params => {
   if (
     params.filter &&
     params.filter.length === 2 && 
-    ['mg', 'ch', 'us'].indexOf(params.filter) === -1
+    ['mg', 'ch', 'us', 'rg'].indexOf(params.filter) === -1
   ) {
     const id = getStateFipsFromAbbr(params.filter)
     return [['startsWith', 'id', id]]


### PR DESCRIPTION
Closes #502, reverting school type radio buttons and adding a flag for "regular" schools (non-charter, non-magnet, non-bie).

Viewable [here](https://inspiring-lumiere-20b37d.netlify.app/).

Notes:

- Hard to tell if my "regular" `rg` flag is working properly – there are some schools like "Sam H. Lawson Middle" that have an `rg` flag but still show up when the "regular" checkbox is unchecked. But unchecking this box should render only charter/magnet schools, right? Maybe I'm misunderstanding the logic of the checkboxes. 