### PR TITLE
reintroduce 1.0 styles to help panel

### DIFF
--- a/src/modules/explorer/help/SedaHelpPanel.js
+++ b/src/modules/explorer/help/SedaHelpPanel.js
@@ -2,7 +2,8 @@ import React from 'react'
 import {
   Typography,
   makeStyles,
-  IconButton
+  IconButton,
+  withStyles
 } from '@material-ui/core'
 import {
   SidePanel,
@@ -19,6 +20,35 @@ const useStyles = makeStyles(theme => ({
   root: {},
   title: theme.typography.panelHeading
 }))
+
+const StyledExpansionPanel = withStyles(theme => ({
+  root: {
+    '&.MuiExpansionPanel-root.MuiPaper-root::before': {
+      backgroundColor: '#ECEFF1',
+      opacity: 1,
+      zIndex: 101
+    },
+    '&.Mui-expanded .MuiExpansionPanelSummary-content': {
+      margin: 0
+    }
+  },
+  summary: {
+    padding: `${theme.spacing(1)}px ${theme.spacing(3)}px`,
+    '&:after': {
+      display: 'none'
+    },
+    '& .MuiExpansionPanelSummary-expandIcon': {
+      padding: `0 ${theme.spacing(2)}px`
+    },
+  },
+  details: {
+    padding: `0 ${theme.spacing(3)}px ${theme.spacing(2)}px`,
+  },
+  content: {},
+  heading: {
+    ...theme.mixins.boldType
+  }
+}))(ExpansionPanel)
 
 const topics = new Array(12)
   .fill()
@@ -88,22 +118,22 @@ const SedaHelpPanel = props => {
       </SidePanelHeader>
       <SidePanelBody>
         {topics.map((t, i) => (
-          <ExpansionPanel key={t} title={getLang(t)}>
+          <StyledExpansionPanel key={t} title={getLang(t)}>
             <div
               dangerouslySetInnerHTML={{
                 __html: getLang(`${t}_A`)
               }}
             />
-          </ExpansionPanel>
+          </StyledExpansionPanel>
         ))}
         {additionalTopics.map(q => (
-          <ExpansionPanel key={q.title} title={getLang(q.question)}>
+          <StyledExpansionPanel key={q.question} title={getLang(q.question)}>
             <div
               dangerouslySetInnerHTML={{
                 __html: getLang(q.answer, {region: region})
               }}
             />
-          </ExpansionPanel>
+          </StyledExpansionPanel>
         ))}
       </SidePanelBody>
     </SidePanel>


### PR DESCRIPTION
Closes #524, re-introducing 1.0 styles to the help panel.

Viewable [here](https://zen-cray-48030b.netlify.app/).

Notes:
- I tried my best to pull the relevant styles from 1.0 while sticking to our same theme – this means that borders and backgrounds should look pretty similar but copy looks a bit different just because we're using different typefaces in this version. Lmk if anything looks off, I can adjust quickly.