### PR TITLE
add aria-labels

### DIFF
--- a/src/modules/explorer/app/components/header/SedaHeaderDataButton.js
+++ b/src/modules/explorer/app/components/header/SedaHeaderDataButton.js
@@ -129,7 +129,8 @@ const SedaHeaderDataButton = ({classes}) => {
       >
       <IconButton
         className={classes.root}
-        onClick={handleToggleSettings}>
+        onClick={handleToggleSettings}
+        aria-label="toggle options">
         <SettingsIcon className={classes.logo} />
       </IconButton>
     </Tooltip>

--- a/src/modules/explorer/help/SedaHelpPanel.js
+++ b/src/modules/explorer/help/SedaHelpPanel.js
@@ -112,7 +112,7 @@ const SedaHelpPanel = props => {
         <Typography className={classes.title}>
           Help Panel
         </Typography>
-        <IconButton onClick={toggleHelp}>
+        <IconButton onClick={toggleHelp} aria-label="close">
           <CloseIcon />
         </IconButton>
       </SidePanelHeader>

--- a/src/modules/explorer/search/components/SedaSearch.js
+++ b/src/modules/explorer/search/components/SedaSearch.js
@@ -38,7 +38,7 @@ const SedaSearch = ({
       onSuggestionSelected={handleSelected}
       onSelectedClear={handleCleared}
       indices={indices}
-      inputProps={{ ...inputProps, placeholder }}
+      inputProps={{ ...inputProps, placeholder, "aria-label": "search" }}
       TextFieldProps={TextFieldProps}
       {...props}
     />


### PR DESCRIPTION
Closes #540, closes #541, closes #542, closes #543.

Notes:
- for the search bar in `SedaSearch.js`, it doesn't seem like `AlgoliaSearch` allows an `aria-label` to be passed all the way down to the input. Stops and renders at the parent div every time – lmk if you know a fix for this. 