### PR TITLE
clear filter when SES is not present

### DIFF
--- a/src/modules/explorer/app/selectors/data.js
+++ b/src/modules/explorer/app/selectors/data.js
@@ -139,6 +139,14 @@ const getMetricVarName = (metric, demographic = 'all') => {
   return demographic + '_' + metric
 }
 
+/**
+ * Gets the secondary var name for the given demographic
+ * and substitues "all" for the demographic if SES is
+ * unavailable for the given demographic.
+ * @param {*} secondary
+ * @param {*} demographic
+ * @returns
+ */
 const getSecondaryVarName = (secondary, demographic) => {
   // use "all" SES option for the following demographics
   if (secondary === 'ses') {

--- a/src/modules/explorer/app/selectors/metrics.js
+++ b/src/modules/explorer/app/selectors/metrics.js
@@ -30,8 +30,9 @@ export const getMetricById = id =>
  * @param {*} dem
  */
 export const getSecondaryForDemographic = dem => {
+  // non-gaps only have ses
   const metrics = {
-    ses: ['wb', 'wh'],
+    ses: ['all', 'w', 'b', 'h', 'a', 'i', 'wb', 'wh'],
     seg: ['wb', 'wh', 'pn'],
     min: ['wb', 'wh']
   }


### PR DESCRIPTION
fixes issue where charts would be blank when SES filter is applied to subgroup with no SES values