### PR TITLE
fix overlay z index

### DIFF
--- a/src/modules/explorer/panels/components/SedaPreviewChartPanel.js
+++ b/src/modules/explorer/panels/components/SedaPreviewChartPanel.js
@@ -72,7 +72,8 @@ const useChartOverlayStyles = makeStyles(theme => ({
     left: theme.spacing(3),
     width: `calc(100% - ${theme.spacing(6)}px)`,
     height: `calc(100% - ${theme.spacing(3)}px)`,
-    overflow: 'hidden'
+    overflow: 'hidden',
+    zIndex: 1
   },
   inner: {
     padding: theme.spacing(3),

--- a/src/modules/explorer/scatterplot/components/SedaScatterplotPreview.js
+++ b/src/modules/explorer/scatterplot/components/SedaScatterplotPreview.js
@@ -11,6 +11,7 @@ const useStyles = makeStyles(theme => ({
     height: 200,
     marginRight: 0,
     marginBottom: 0,
+    zIndex: 0,
     '&:before': {
       content: '""',
       display: 'block',


### PR DESCRIPTION
Pretty simple, just adds a z-index to the chart preview hover overlay, keeping it above the selected points.