### PR TITLE
Add disabled state to checkboxes w/ tooltip

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ The following is a set of guidelines for contributing to the [Educational Opport
     - [Modules (`/src/modules`)](#modules-srcmodules)
   - [Application State](#application-state)
   - [Environment Variables](#environment-variables)
+  - [Language Strings](#language-strings)
 - [How Can I Contribute?](#how-can-i-contribute)
   - [Reporting Bugs](#reporting-bugs)
   - [Suggesting Features](#suggesting-features)
@@ -98,6 +99,17 @@ REACT_APP_TILESET_SUFFIX=         # suffix used for the tileset name (e.g. 4-1-0
 ```
 
 If you require any of these values, ask for them on Slack or look in the "Hyperobjekt Assets" folder on drive (Hyperobjekt Assets > SEDA > Development).
+
+### Language Strings
+
+No hardcoded language strings should be used in the app. All strings consist of key / value pairs that are loaded on build from a [shared google sheet](https://docs.google.com/spreadsheets/d/1L633lO5wfQGLbaVnaSnIg9TrprX9k4Ie8qe_CLDmQN8/edit#gid=0), request access if needed.
+
+To add a new string to the sheet:
+
+- add a new row to the sheet
+- in the key column, enter a key for the string. make it descriptive so you can determine the purpose of the string.
+- add the string content in the value field. you can interpolate variables into the string by using the format `$[variable]`. you will need to restart your development server to fetch any new entries.
+- use the `getLang` utility function to retrieve the value (e.g. `getLang("MY_STRING_KEY")` or `getLang("MY_STRING_KEY", { value: "something" })` to provide a value to interpolate.)
 
 ## How Can I Contribute?
 

--- a/src/modules/explorer/app/constants/flags.js
+++ b/src/modules/explorer/app/constants/flags.js
@@ -7,13 +7,19 @@ export const FILTER_FLAGS = {
   districts: [['r', 't', 's', 'u']],
   schools: [
     ['r', 't', 's', 'u'],
-    ['rg', 'ch', 'mg'],
+    ['rg', 'ch', 'mg', 'bie'],
     ['m', 'e', 'c']
   ]
 }
 
+export const ALL_FILTER_FLAGS = [
+  ['r', 't', 's', 'u'],
+  ['rg', 'ch', 'mg', 'bie'],
+  ['m', 'e', 'c']
+]
+
 // add BIE filter to embargoed
-FILTER_FLAGS['schools'][1].push(['bie'])
+// FILTER_FLAGS['schools'][1].push(['bie'])
 
 // these flags only show locations with corresponding flags when active
 // not currently in use, but was used for BIE filter, and left in incase

--- a/src/modules/explorer/filters/components/SedaFilterFlags.js
+++ b/src/modules/explorer/filters/components/SedaFilterFlags.js
@@ -135,30 +135,8 @@ const SedaFilterFlags = ({ classes, className, ...props }) => {
     <PanelListItem
       className={clsx(classes.root, className)}
       {...props}>
-      {checkboxGroups.map((group, i) =>
-        i + 1 > regionFlags.length ? (
-          <Tooltip
-            arrow
-            title={`These filters are only available in ${getAvailableRegions(
-              group
-            )} view`}
-            placement="right">
-            <FormControl
-              className={classes.group}
-              key={i}
-              component="fieldset">
-              <FormLabel
-                className={classes.label}
-                component="legend">
-                {GROUP_TITLES[i]}
-              </FormLabel>
-              <CheckboxGroup
-                checkboxes={group}
-                onChange={handleCheckboxChange}
-              />
-            </FormControl>
-          </Tooltip>
-        ) : (
+      {checkboxGroups.map((group, i) => {
+        const checkboxes = (
           <FormControl
             className={classes.group}
             key={i}
@@ -174,7 +152,19 @@ const SedaFilterFlags = ({ classes, className, ...props }) => {
             />
           </FormControl>
         )
-      )}
+        return i + 1 > regionFlags.length ? (
+          <Tooltip
+            arrow
+            title={getLang('TOOLTIP_HINT_REGION_FILTER', {
+              regions: getAvailableRegions(group)
+            })}
+            placement="top">
+            {checkboxes}
+          </Tooltip>
+        ) : (
+          checkboxes
+        )
+      })}
     </PanelListItem>
   )
 }

--- a/src/modules/explorer/filters/components/SedaFilterFlags.js
+++ b/src/modules/explorer/filters/components/SedaFilterFlags.js
@@ -3,6 +3,7 @@ import clsx from 'clsx'
 import { CheckboxGroup } from '../../../../shared/components/Inputs/Checkboxes'
 import { useRegion } from '../../app/hooks'
 import {
+  ALL_FILTER_FLAGS,
   EXCLUSIVE_FLAGS,
   FILTER_FLAGS
 } from '../../app/constants/flags'
@@ -13,6 +14,7 @@ import useFilterStore from '../../../filters'
 import {
   FormControl,
   FormLabel,
+  Tooltip,
   withStyles
 } from '@material-ui/core'
 import { hasFilterRule } from '../../../filters/useFilterStore'
@@ -29,11 +31,12 @@ const styles = theme => ({
   }
 })
 
-const makeCheckboxes = (flags, checked) => {
+const makeCheckboxes = (flags, checked, regionFlags) => {
   return flags.map(flag => ({
     id: flag,
     label: getPrefixLang(flag, 'FLAG_LABEL'),
-    checked: checked.indexOf(flag) > -1
+    checked: checked.indexOf(flag) > -1,
+    disabled: regionFlags.indexOf(flag) < 0
   }))
 }
 
@@ -68,6 +71,18 @@ const getUncheckedFlags = filters => {
   return [...uncheckedNonExclusive, ...uncheckedExclusive]
 }
 
+const getAvailableRegions = filters => {
+  const availableRegions = Object.keys(FILTER_FLAGS)
+    .filter(
+      g =>
+        FILTER_FLAGS[g].flat().length > 0 &&
+        FILTER_FLAGS[g].flat().indexOf(filters[0].id) > -1
+    )
+    .join(' or ')
+
+  return availableRegions
+}
+
 const SedaFilterFlags = ({ classes, className, ...props }) => {
   const [region] = useRegion()
 
@@ -89,8 +104,12 @@ const SedaFilterFlags = ({ classes, className, ...props }) => {
   const setFilter = useFilterStore(state => state.setFilter)
   // get checkbox group from flags and active filters
   const checkboxGroups = useMemo(() => {
-    return regionFlags.map(flagGroup =>
-      makeCheckboxes(flagGroup, checkedFlags)
+    return ALL_FILTER_FLAGS.map((flagGroup, i) =>
+      makeCheckboxes(
+        flagGroup,
+        checkedFlags,
+        regionFlags.length > i ? regionFlags[i] : []
+      )
     )
   }, [checkedFlags, regionFlags])
 
@@ -112,27 +131,50 @@ const SedaFilterFlags = ({ classes, className, ...props }) => {
       ? setFilter(['neq', key, 1])
       : removeFilter(['neq', key], true)
   }
-
   return (
     <PanelListItem
       className={clsx(classes.root, className)}
       {...props}>
-      {checkboxGroups.map((group, i) => (
-        <FormControl
-          className={classes.group}
-          key={i}
-          component="fieldset">
-          <FormLabel
-            className={classes.label}
-            component="legend">
-            {GROUP_TITLES[i]}
-          </FormLabel>
-          <CheckboxGroup
-            checkboxes={group}
-            onChange={handleCheckboxChange}
-          />
-        </FormControl>
-      ))}
+      {checkboxGroups.map((group, i) =>
+        i + 1 > regionFlags.length ? (
+          <Tooltip
+            arrow
+            title={`These filters are only available in ${getAvailableRegions(
+              group
+            )} view`}
+            placement="right">
+            <FormControl
+              className={classes.group}
+              key={i}
+              component="fieldset">
+              <FormLabel
+                className={classes.label}
+                component="legend">
+                {GROUP_TITLES[i]}
+              </FormLabel>
+              <CheckboxGroup
+                checkboxes={group}
+                onChange={handleCheckboxChange}
+              />
+            </FormControl>
+          </Tooltip>
+        ) : (
+          <FormControl
+            className={classes.group}
+            key={i}
+            component="fieldset">
+            <FormLabel
+              className={classes.label}
+              component="legend">
+              {GROUP_TITLES[i]}
+            </FormLabel>
+            <CheckboxGroup
+              checkboxes={group}
+              onChange={handleCheckboxChange}
+            />
+          </FormControl>
+        )
+      )}
     </PanelListItem>
   )
 }

--- a/src/modules/explorer/filters/components/SedaFiltersForm.js
+++ b/src/modules/explorer/filters/components/SedaFiltersForm.js
@@ -13,7 +13,7 @@ import { formatInteger } from '../../../../shared/utils'
 /**
  * Contains all controls for modifying filters
  */
-const SedaFiltersForm = (props) => {
+const SedaFiltersForm = props => {
   const {
     filterResults,
     totalResults,
@@ -59,9 +59,7 @@ const SedaFiltersForm = (props) => {
           isActive={metric === activeMetric}
         />
       ))}
-      {(region === 'schools' || region === 'districts') && (
-        <SedaFilterFlags />
-      )}
+      <SedaFilterFlags />
     </List>
   )
 }


### PR DESCRIPTION
Refactors the filters panel to show all checkboxes, disabling them with a helpful tooltip when not in use. 

Note: I'm placing the tooltip to the right on desktop since that seemed best, but it might not be the best placement on mobile. Either way I think this is a good start – we can cross that bridge soon.