### PR TITLE
Fix scatterplot axis

### DIFF
--- a/src/modules/explorer/app/hooks/useAppContext.js
+++ b/src/modules/explorer/app/hooks/useAppContext.js
@@ -110,17 +110,23 @@ export default function useAppContext() {
 
     // add extents for all vars
     const dataExtents = {}
+    const allDataExtents = {}
     allVars.forEach(v => {
       // #516: do not adjust size extent based on filtered data
       dataExtents[v] =
         v.indexOf('_sz') > -1
           ? getDataExtent(regionData.slice(0, MAX_DOTS), v)
           : getDataExtent(scatterplotData, v)
+
+      allDataExtents[v] =
+        v.indexOf('_sz') > -1
+          ? getDataExtent(regionData.slice(0, MAX_DOTS), v)
+          : getDataExtent(allData, v)
     })
 
     // create padded extents for the scatterplot
     const scatterplotExtents = scatterplotVars.map(v => {
-      const extent = dataExtents[v]
+      const extent = allDataExtents[v]
       // pad extents that are not "size"
       return v.indexOf('sz') > -1
         ? extent


### PR DESCRIPTION
Prevents the scatterplot axis from shifting upon adding filters – accomplished by pulling `scatterplotExtents` from `allData`:

```
    // add extents for all vars
    const dataExtents = {}
    const allDataExtents = {}
    allVars.forEach(v => {
      // #516: do not adjust size extent based on filtered data
      dataExtents[v] =
        v.indexOf('_sz') > -1
          ? getDataExtent(regionData.slice(0, MAX_DOTS), v)
          : getDataExtent(scatterplotData, v)

      allDataExtents[v] =
        v.indexOf('_sz') > -1
          ? getDataExtent(regionData.slice(0, MAX_DOTS), v)
          : getDataExtent(allData, v)
    })

    // create padded extents for the scatterplot
    const scatterplotExtents = scatterplotVars.map(v => {
      const extent = allDataExtents[v]
      // pad extents that are not "size"
      return v.indexOf('sz') > -1
        ? extent
        : getPaddedExtent(extent, 0.05)
    })
```

Wasn't exactly sure how to implement this in the cleanest way possible, so took a stab but happy to refactor as needed. 